### PR TITLE
Discussion needed: Add ESLint rule for space-before-function-paren

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,6 +28,10 @@ module.exports = {
             "error",
             "always"
         ],
+        "space-before-function-paren": [
+            "error",
+            {"anonymous": "always", "named": "never"}
+        ],
         "max-len": [
             "error",
             120


### PR DESCRIPTION
There seems to be some inconsistency in how functions are declared with spacing, but I'm not sure what the preferred style is. This change makes it look similar to [this](https://eslint.org/docs/rules/space-before-function-paren#anonymous-always-named-never-asyncarrow-always) (e.g. Crockford-style, if it can be called that).