### PR TITLE
Throw error if config is not valid JSON

### DIFF
--- a/solhint.js
+++ b/solhint.js
@@ -101,7 +101,7 @@ const readConfig = _.memoize(function () {
         config.excludedFiles = [].concat(_.flatten(config.excludedFiles), readIgnore());
 
         return config;
-    } catch catch (e){
+    } catch (e) {
         if (e instanceof SyntaxError) {
             console.log('Configuration file is not valid JSON');
             throw e;

--- a/solhint.js
+++ b/solhint.js
@@ -101,8 +101,13 @@ const readConfig = _.memoize(function () {
         config.excludedFiles = [].concat(_.flatten(config.excludedFiles), readIgnore());
 
         return config;
-    } catch (e) {
-        return { rules: {} };
+    } catch catch (e){
+        if (e instanceof SyntaxError) {
+            console.log('Configuration file is not valid JSON');
+            throw e;
+        } else {
+            throw e;
+        }
     }
 });
 


### PR DESCRIPTION
##  What I did:

Made it so that an error is thrown if the config file is invalid JSON.

## Why I did it

I think it's dangerous and misleading to silently handle the error by using an empty config object.

## How to verify it

I wasn't sure how to test this, since all the tests use `linter.processStr()`, which takes a `config`, but in practice solhint.js looks for a file.

