### PR TITLE
Use exact match when checking for deprecated functions

### DIFF
--- a/lib/rules/security/avoid-deprecations.js
+++ b/lib/rules/security/avoid-deprecations.js
@@ -8,13 +8,13 @@ class AvoidDeprecationsChecker extends BaseChecker {
     }
 
     exitIdentifier(ctx) {
-        const text = ctx.getText();
+        const identifier = ctx.Identifier().toString();
 
-        if (text.includes('sha3')) {
+        if (identifier === 'sha3') {
             this.error(ctx, 'avoid-sha3', 'Use "keccak256" instead of deprecated "sha3"');
         }
 
-        if (text.includes('suicide')) {
+        if (identifier === 'suicide') {
             this.error(ctx, 'avoid-suicide', 'Use "selfdestruct" instead of deprecated "suicide"');
         }
     }

--- a/test/security-rules.js
+++ b/test/security-rules.js
@@ -116,6 +116,17 @@ describe('Linter - SecurityRules', function () {
             assert.ok(report.reports[0].message.includes('deprecate'));
         }));
 
+    const ALMOST_DEPRECATION_ERRORS = ['sha33("test");', 'throwing;', 'suicides();'];
+
+    ALMOST_DEPRECATION_ERRORS.forEach(curText =>
+        it(`should not return error when doing ${curText}`, function () {
+            const code = funcWith(curText);
+
+            const report = linter.processStr(code, noIndent());
+
+            assert.equal(report.errorCount, 0);
+        }));
+
     it('should return error that multiple send calls used in transation', function () {
         const code = funcWith(`
           uint aRes = a.send(1);


### PR DESCRIPTION
Instead of using `.includes` for checking if a method is `suicide` or `sha3`, make an exact comparison with the identifier. Otherwise, functions like `get_sha3` or `suicideTimes` are interpreted as deprecated.

Note that this is still not perfect, because then you can't use `sha3` as a variable name (this seems valid, although the compiler emits a warning). But checking if the identifier is part of a function call is a little cumbersome, at least with the current grammar.