### PR TITLE
Add --quiet option 

### DIFF
--- a/solhint.js
+++ b/solhint.js
@@ -14,11 +14,9 @@ function init() {
     program
         .usage('[options] <file> [...other_files]')
         .option('-f, --formatter [name]', 'report formatter name (stylish, table, tap, unix)')
+        .option('-q, --quiet', 'report errors only - default: false')
         .description('Linter for Solidity programming language')
         .action(execMainAction);
-
-    program
-        .option('-q, --quiet', 'report errors only - default: false');
 
     program
         .command('stdin')
@@ -43,8 +41,8 @@ function execMainAction() {
     const reports =_.flatten(reportLists);
 
     if (program.quiet) {
-        // Setting int the report list errors only.
-        reports[0].reports  = getErrorResults(reports);
+        // filter the list of reports, to set errors only.
+        reports[0].reports  = reports[0].reports.filter(i => i.severity === 2);
     }
 
     printReports(reports, program.formatter);
@@ -119,17 +117,6 @@ function processStr(input) {
 
 function processPath(path) {
     return linter.processPath(path, readConfig());
-}
-
-
-/**
-     * Returns results that only contains errors.
-     * @param {LintResult[]} reporter The results to filter.
-     * @returns {LintResult[]} The filtered results.
-**/
-function getErrorResults(reporter) {
-    return reporter[0].reports.filter(i => i.severity === 2);
-
 }
 
 function printReports(reports, formatter) {

--- a/solhint.js
+++ b/solhint.js
@@ -18,6 +18,11 @@ function init() {
         .action(execMainAction);
 
     program
+        .usage('[options] <file> [...other_files]')
+        .option('-q, --quiet', 'report errors only - default: false')
+        .action(execMainAction);
+
+    program
         .command('stdin')
         .description('linting of source code data provided to STDIN')
         .option('--filename [file_name]', 'name of file received using STDIN')
@@ -38,6 +43,12 @@ function init() {
 function execMainAction() {
     const reportLists = program.args.filter(_.isString).map(processPath);
     const reports =_.flatten(reportLists);
+
+    if (program.quiet) {
+        console.log('::::Quiet mode enabled - filtering out warnings::::');
+        // Setting int the report list errors only.
+        reports[0].reports  = getErrorResults(reports);
+    }
 
     printReports(reports, program.formatter);
     exitWithCode(reports);
@@ -111,6 +122,17 @@ function processStr(input) {
 
 function processPath(path) {
     return linter.processPath(path, readConfig());
+}
+
+
+/**
+     * Returns results that only contains errors.
+     * @param {LintResult[]} reporter The results to filter.
+     * @returns {LintResult[]} The filtered results.
+**/
+function getErrorResults(reporter) {
+    const reporterErrors = reporter[0].reports.filter(i => i.severity === 2);
+    return reporterErrors;
 }
 
 function printReports(reports, formatter) {

--- a/solhint.js
+++ b/solhint.js
@@ -18,9 +18,7 @@ function init() {
         .action(execMainAction);
 
     program
-        .usage('[options] <file> [...other_files]')
-        .option('-q, --quiet', 'report errors only - default: false')
-        .action(execMainAction);
+        .option('-q, --quiet', 'report errors only - default: false');
 
     program
         .command('stdin')
@@ -45,7 +43,6 @@ function execMainAction() {
     const reports =_.flatten(reportLists);
 
     if (program.quiet) {
-        console.log('::::Quiet mode enabled - filtering out warnings::::');
         // Setting int the report list errors only.
         reports[0].reports  = getErrorResults(reports);
     }
@@ -131,8 +128,8 @@ function processPath(path) {
      * @returns {LintResult[]} The filtered results.
 **/
 function getErrorResults(reporter) {
-    const reporterErrors = reporter[0].reports.filter(i => i.severity === 2);
-    return reporterErrors;
+    return reporter[0].reports.filter(i => i.severity === 2);
+
 }
 
 function printReports(reports, formatter) {


### PR DESCRIPTION

# Description

It was added --quiet (-q) option that allows to report errors only, filtering out warnings reports.
Its resolves an item of Issue #5 

To do this, it was modified execMainAction(), and it was added a function that filter errors reports.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update