### PR TITLE
Add --max-warnings [int] option

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,20 +2,20 @@
 title:       Solhint - Solidity Linter
 date:        2017-10-23 14:16:00 +0300
 author:      "@drabenia"
-description: This is an open source project for validating Solidity code. 
+description: This is an open source project for validating Solidity code.
              The project provides solidity security, style guide and best practise validations.
 ---
 
 ## Solhint Project
 
 [![Build Status](https://travis-ci.org/protofire/solhint.svg?branch=master)](https://travis-ci.org/protofire/solhint)
-[![npm version](http://img.shields.io/npm/v/solhint.svg?style=flat)](https://npmjs.org/package/solhint 
+[![npm version](http://img.shields.io/npm/v/solhint.svg?style=flat)](https://npmjs.org/package/solhint
 "View this project on npm")
 [![Coverage Status](https://coveralls.io/repos/github/protofire/solhint/badge.svg?branch=master)](
 https://coveralls.io/github/protofire/solhint?branch=master)
 
-This is an open source project for linting [solidity](http://solidity.readthedocs.io/en/develop/) code. This project 
-provide both **security** and **style guide** validations.   
+This is an open source project for linting [solidity](http://solidity.readthedocs.io/en/develop/) code. This project
+provide both **security** and **style guide** validations.
 
 ### Installation
 
@@ -30,8 +30,8 @@ solhint -V
 
 ### Usage
 
-For linting Solidity files you need to run Solhint with one or more 
-[Globs](https://en.wikipedia.org/wiki/Glob_(programming)) as arguments. For example, to lint all files inside 
+For linting Solidity files you need to run Solhint with one or more
+[Globs](https://en.wikipedia.org/wiki/Glob_(programming)) as arguments. For example, to lint all files inside
 `contracts` directory, you can do:
 
 ```sh
@@ -65,15 +65,17 @@ Commands:
   init-config             create sample solhint config in current folder
 ```
 
+You can use any formatter supported by ESLint. See the full list
+[here](https://eslint.org/docs/user-guide/formatters/).
+
 ### Docs
 
  - [List of Rules](./rules.html)
  - [Configuration](./configuration.html)
- - [Formatters](https://eslint.org/docs/user-guide/formatters/)
  - [Use Solhint in Your Application](./use-in-app.html)
 
 ### IDE Integrations
- 
+
   - [Sublime Text 3](https://packagecontrol.io/search/solhint)
   - [Atom](https://atom.io/packages/atom-solidity-linter)
   - [Vim](https://github.com/sohkai/syntastic-local-solhint)

--- a/solhint.js
+++ b/solhint.js
@@ -15,6 +15,7 @@ function init() {
         .usage('[options] <file> [...other_files]')
         .option('-f, --formatter [name]', 'report formatter name (stylish, table, tap, unix)')
         .option('-w, --max-warnings [maxWarningsNumber]', 'number of warnings to trigger nonzero exit code')
+        .option('-q, --quiet', 'report errors only')
         .description('Linter for Solidity programming language')
         .action(execMainAction);
 
@@ -39,12 +40,18 @@ function init() {
 function execMainAction() {
     const reportLists = program.args.filter(_.isString).map(processPath);
     const reports =_.flatten(reportLists);
+    const warningsNumberExceeded = program.maxWarnings >= 0 && reports[0].warningCount >= program.maxWarnings;
+
+    if (program.quiet) {
+        // filter the list of reports, to set errors only.
+        reports[0].reports  = reports[0].reports.filter(i => i.severity === 2);
+    }
 
     if (printReports(reports, program.formatter)) {
-        const warningsNumberExceeded = program.maxWarnings >= 0 && reports[0].warningCount > program.maxWarnings;
-
         if (program.maxWarnings && !reports[0].errorCount && warningsNumberExceeded) {
-            console.log('Solhint found more warnings than the maximum specified (maximum:%s).\n', program.maxWarnings);
+            console.log(
+                'Solhint found more warnings than the maximum specified (maximum: %s)',
+                program.maxWarnings);
             process.exit(1);
         }
     }
@@ -121,7 +128,6 @@ function processStr(input) {
 function processPath(path) {
     return linter.processPath(path, readConfig());
 }
-
 
 function printReports(reports, formatter) {
     const formatterName = formatter || 'stylish';


### PR DESCRIPTION
# Description

It was added --max-warnings [int] option:  Number of warnings to trigger nonzero exit code.

It resolves issue #56.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update
- [x] Existing unit tests pass locally with my changes