### PR TITLE
Remove rules enumeration from README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Solhint Project
+# Solhint Project
 
 [![Build Status](https://travis-ci.org/protofire/solhint.svg?branch=master)](https://travis-ci.org/protofire/solhint)
 [![NPM version](https://badge.fury.io/js/solhint.svg)](https://npmjs.org/package/solhint)
@@ -11,7 +11,7 @@ https://coveralls.io/github/protofire/solhint?branch=master)
 This is an open source project for linting [Solidity](http://solidity.readthedocs.io/en/develop/) code. This project
 provides both **Security** and **Style Guide** validations.
 
-### Installation
+## Installation
 
 You can install Solhint using **npm**:
 
@@ -22,7 +22,7 @@ npm install -g solhint
 solhint -V
 ```
 
-### Usage
+## Usage
 
 For linting Solidity files you need to run Solhint with one or more [Globs](https://en.wikipedia.org/wiki/Glob_(programming)) as arguments. For example, to lint all files inside `contracts` directory, you can do:
 
@@ -61,7 +61,7 @@ Commands:
   init-config             create sample solhint config in current folder
 ```
 
-### Configuration
+## Configuration
 
 You can use a `.solhint.json` file to configure Solhint globally. This file has the following
 format:
@@ -137,79 +137,19 @@ Or disable all validations for a group of lines:
   /* solhint-enable */
 ```
 
+## Rules
 ### Security Rules
-
- | Rule ID                       |                      Error                                        |
- |-------------------------------|-------------------------------------------------------------------|
- | **reentrancy**                | Possible reentrancy vulnerabilities. Avoid state changes after transfer. |
- | **avoid-sha3**                | Use "keccak256" instead of deprecated "sha3"                      |
- | **avoid-suicide**             | Use "selfdestruct" instead of deprecated "suicide"                |
- | **avoid-throw**               | "throw" is deprecated, avoid to use it                            |
- | **func-visibility**           | Explicitly mark visibility in function                            |
- | **state-visibility**          | Explicitly mark visibility of state                               |
- | **check-send-result**         | Check result of "send" call                                       |
- | **avoid-call-value**          | Avoid to use ".call.value()()"                                    |
- | **compiler-fixed**            | Compiler version must be fixed                                    |
- | **compiler-gt-0_4**           | Use at least '0.4' compiler version                               |
- | **no-complex-fallback**       | Fallback function must be simple                                  |
- | **mark-callable-contracts**   | Explicitly mark all external contracts as trusted or untrusted    |
- | **multiple-sends**            | Avoid multiple calls of "send" method in single transaction       |
- | **no-simple-event-func-name** | Event and function names must be different                        |
- | **avoid-tx-origin**           | Avoid to use tx.origin                                            |
- | **no-inline-assembly**        | Avoid to use inline assembly. It is acceptable only in rare cases |
- | **not-rely-on-block-hash**    | Do not rely on "block.blockhash". Miners can influence its value. |
- | **avoid-low-level-calls**     | Avoid to use low level calls.                                     |
-
-\* \- All security rules implemented according [ConsenSys Guide for Smart Contracts](
-https://consensys.github.io/smart-contract-best-practices/recommendations/)
-
+[Full list with all supported Security Rules](https://github.com/protofire/solhint/blob/master/docs/rules.md#security-rules)
 ### Style Guide Rules
+[Full list with all supported Style Guide Rules](https://github.com/protofire/solhint/blob/master/docs/rules.md#style-guide-rules)
+### Best Practices Rules
+[Full list with all supported Best Practices Rules](https://github.com/protofire/solhint/blob/master/docs/rules.md#best-practise-rules)
 
- | Rule ID                       |                      Error                                                |
- |-------------------------------|---------------------------------------------------------------------------|
- | **func-name-mixedcase**       | Function name must be in camelCase                                        |
- | **func-param-name-mixedcase** | Function param name must be in mixedCase                                  |
- | **var-name-mixedcase**        | Variable name must be in mixedCase                                        |
- | **event-name-camelcase**      | Event name must be in CamelCase                                           |
- | **const-name-snakecase**      | Constant name must be in capitalized SNAKE_CASE                           |
- | **modifier-name-mixedcase**   | Modifier name must be in mixedCase                                        |
- | **contract-name-camelcase**   | Contract name must be in CamelCase                                        |
- | **use-forbidden-name**        | Avoid to use letters 'I', 'l', 'O' as identifiers                         |
- | **visibility-modifier-order** | Visibility modifier must be first in list of modifiers                    |
- | **imports-on-top**            | Import statements must be on top                                          |
- | **two-lines-top-level-separator** | Definition must be surrounded with two blank line indent              |
- | **func-order**                | Function order is incorrect                                               |
- | **quotes**                    | Use double quotes for string literals                                     |
- | **no-mix-tabs-and-spaces**    | Mixed tabs and spaces                                                     |
- | **indent**                    | Indentation is incorrect                                                  |
- | **bracket-align**             | Open bracket must be on same line. It must be indented by other constructions by space |
- | **array-declaration-spaces**  | Array declaration must not contains spaces                                |
- | **separate-by-one-line-in-contract** | Definitions inside contract / library must be separated by one line|
- | **expression-indent**         | Expression indentation is incorrect.                                      |
- | **statement-indent**          | Statement indentation is incorrect.                                       |
- | **space-after-comma**         | Comma must be separated from next element by space                        |
- | **no-spaces-before-semicolon**| Semicolon must not have spaces before                                     |
-
-\* \- All style guide rules implemented according [Solidity Style Guide](
-http://solidity.readthedocs.io/en/develop/style-guide.html)
-
-### Best Practise Rules
-
-  | Rule ID                       |                      Error                                                       |
-  |-------------------------------|----------------------------------------------------------------------------------|
-  | **max-line-length**           | Line length must be no more than 120 but current length is 121.                  |
-  | **payable-fallback**          | When fallback is not payable you will not be able to receive ethers              |
-  | **no-empty-blocks**           | Code contains empty block                                                        |
-  | **no-unused-vars**            | Variable "name" is unused                                                        |
-  | **function-max-lines**        | Function body contains "count" lines but allowed no more than "maxLines" lines   |
-  | **code-complexity**           | Function has cyclomatic complexity "current" but allowed no more than "max"      |
-  | **max-states-count**          | Contract has "curCount" states declarations but allowed no more than "max"       |
-
-### Documentation
+## Documentation
 
 Related documentation you may find [there](https://protofire.github.io/solhint/).
 
-### IDE Integrations
+## IDE Integrations
 
   - **[Sublime Text 3](https://packagecontrol.io/search/solhint)**
   - **[Atom](https://atom.io/packages/atom-solidity-linter)**
@@ -220,20 +160,20 @@ Related documentation you may find [there](https://protofire.github.io/solhint/)
   - **[VS Code: Solidity Language Support by CodeChain.io](
          https://marketplace.visualstudio.com/items?itemName=kodebox.solidity-language-server)**
 
-### Acknowledgements
+## Acknowledgements
 
 The grammar used by solhint was created and is maintained by [Federico Bond](https://github.com/federicobond).
 You can find it [here](https://github.com/solidityj/solidity-antlr4).
 
-### Licence
+## Licence
 
 MIT
 
-### Who uses solhint?
+## Who uses solhint?
 
 [<img src="https://avatars2.githubusercontent.com/u/28943015?s=200&v=4" width="75px" height="75px" alt="POA Network - Public EVM Sidechain" title="POA Network - Public EVM Sidechain" style="margin: 20px 20px 0 0" />](https://github.com/poanetwork) [<img src="https://avatars3.githubusercontent.com/u/24832717?s=200&v=4" width="75px" height="75px" alt="0x" title="0x" style="margin: 20px 20px 0 0" />](https://github.com/0xProject) [<img src="https://avatars1.githubusercontent.com/u/24954468?s=200&v=4" width="75px" height="75px" alt="GNOSIS" title="GNOSIS" style="margin: 20px 20px 0 0"/>](https://github.com/gnosis)
 
-#### Projects
+### Projects
 
 - [POA Network - Proof of Bank Account (PoBA)](https://github.com/poanetwork/poa-poba)
 - [0x](https://github.com/0xProject/0x-monorepo/tree/development/packages/contracts)


### PR DESCRIPTION
Closes #65 

This PR removes rules sections descriptions out from readme file, by:
- Removing `Security Rules` enumeration and linking it's own section at `/docs/rules.md`
- Removing `Style Guide Rules` enumeration and linking it's own section at `/docs/rules.md`
- Removing `Best Practices Rules` enumeration and linking it's own section at `/docs/rules.md`

Besides, updates a few sections' titles' sizes.