### PR TITLE
Add Black Duck CoPilot integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,6 @@ language: node_js
 
 node_js:
   - "stable"
+
+after_success:
+  - bash <(curl -s https://copilot.blackducksoftware.com/ci/travis/scripts/upload)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/protofire/solhint/badge.svg?branch=master)](
 https://coveralls.io/github/protofire/solhint?branch=master)
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/protofire/solhint/master/LICENSE)
+[![Black Duck Security Risk](https://copilot.blackducksoftware.com/github/repos/protofire/solhint/branches/master/badge-risk.svg)](https://copilot.blackducksoftware.com/github/repos/protofire/solhint/branches/master)
 [![dependencies Status](https://david-dm.org/protofire/solhint/status.svg)](https://david-dm.org/protofire/solhint)
 [![devDependencies Status](https://david-dm.org/protofire/solhint/dev-status.svg)](https://david-dm.org/protofire/solhint?type=dev)
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 [![NPM version](https://badge.fury.io/js/solhint.svg)](https://npmjs.org/package/solhint)
 [![Coverage Status](https://coveralls.io/repos/github/protofire/solhint/badge.svg?branch=master)](
 https://coveralls.io/github/protofire/solhint?branch=master)
-[![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/protofire/solhint/master/LICENSE)
 [![Black Duck Security Risk](https://copilot.blackducksoftware.com/github/repos/protofire/solhint/branches/master/badge-risk.svg)](https://copilot.blackducksoftware.com/github/repos/protofire/solhint/branches/master)
 [![dependencies Status](https://david-dm.org/protofire/solhint/status.svg)](https://david-dm.org/protofire/solhint)
 [![devDependencies Status](https://david-dm.org/protofire/solhint/dev-status.svg)](https://david-dm.org/protofire/solhint?type=dev)
+[![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/protofire/solhint/master/LICENSE)
 
 This is an open source project for linting [Solidity](http://solidity.readthedocs.io/en/develop/) code. This project
 provides both **Security** and **Style Guide** validations.


### PR DESCRIPTION
> Black Duck CoPilot helps you find, fix, and avoid vulnerable dependencies in your open source projects.

This PR adds integration with [Black Duck CoPilot](https://copilot.blackducksoftware.com/github/repos/protofire/solhint/results) by:

- Adding a new step after build succeeds to trigger report (re)generation 
- Adding a badge to README file

![image](https://user-images.githubusercontent.com/1939415/47855731-1e828980-ddc4-11e8-8f69-f713f264b470.png)

