### PR TITLE
Have --max-warnings better reflect its name

### DIFF
--- a/solhint.js
+++ b/solhint.js
@@ -17,7 +17,7 @@ function init() {
     .option('-f, --formatter [name]', 'report formatter name (stylish, table, tap, unix)')
     .option(
       '-w, --max-warnings [maxWarningsNumber]',
-      'number of allowed warnings to not trigger nonzero exit code'
+      'number of allowed warnings'
     )
     .option('-c, --config [file_name]', 'file to use as your .solhint.json')
     .option('-q, --quiet', 'report errors only - default: false')

--- a/solhint.js
+++ b/solhint.js
@@ -17,7 +17,7 @@ function init() {
     .option('-f, --formatter [name]', 'report formatter name (stylish, table, tap, unix)')
     .option(
       '-w, --max-warnings [maxWarningsNumber]',
-      'number of warnings to trigger nonzero exit code'
+      'number of allowed warnings to not trigger nonzero exit code'
     )
     .option('-c, --config [file_name]', 'file to use as your .solhint.json')
     .option('-q, --quiet', 'report errors only - default: false')
@@ -57,7 +57,7 @@ function execMainAction() {
   const reportLists = program.args.filter(_.isString).map(processPath)
   const reports = _.flatten(reportLists)
   const warningsNumberExceeded =
-    program.maxWarnings >= 0 && reports[0].warningCount >= program.maxWarnings
+    program.maxWarnings >= 0 && reports[0].warningCount > program.maxWarnings
 
   if (program.quiet) {
     // filter the list of reports, to set errors only.


### PR DESCRIPTION
Currently, a run with `--max-warnings 0` always fails, and `max-warnings 1` only succeeds if there are no warnings.

I changed the behavior and updated the description to better reflect the expected behavior.