### PR TITLE
Added disable-previous-line.

### DIFF
--- a/lib/comment-directive-parser.js
+++ b/lib/comment-directive-parser.js
@@ -34,6 +34,16 @@ class CommentDirectiveParser {
       return
     }
 
+    if (text.includes('solhint-disable-previous-line')) {
+      const rules = this.parseRuleIds(text, 'solhint-disable-previous-line')
+
+      if (curLine > 0) {
+        ruleStore.disableRules(curLine - 1, rules)
+      }
+
+      return
+    }
+
     if (text.includes('solhint-disable')) {
       const rules = this.parseRuleIds(text, 'solhint-disable')
 

--- a/test/comment-directives.js
+++ b/test/comment-directives.js
@@ -21,11 +21,24 @@ describe('Linter', () => {
       assertNoErrors(report)
     })
 
-    it('should disable only one compiler error', () => {
+    it('should disable only one compiler error on next line', () => {
       const report = linter.processStr(
         `
                 // solhint-disable-next-line
-                pragma solidity ^0.4.4; 
+                pragma solidity ^0.4.4;
+                pragma solidity 0.3.4;
+            `,
+        noIndent()
+      )
+
+      assertErrorCount(report, 1)
+    })
+
+    it('should disable only one compiler error on previous line', () => {
+      const report = linter.processStr(
+        `
+                pragma solidity ^0.4.4;
+                // solhint-disable-previous-line
                 pragma solidity 0.3.4;
             `,
         noIndent()
@@ -38,7 +51,7 @@ describe('Linter', () => {
       const report = linter.processStr(
         `
                 /* solhint-disable-next-line */
-                pragma solidity ^0.4.4; 
+                pragma solidity ^0.4.4;
                 pragma solidity 0.3.4;
             `,
         noIndent()
@@ -51,7 +64,7 @@ describe('Linter', () => {
       const report = linter.processStr(
         `
                 // solhint-disable compiler-gt-0_4
-                pragma solidity ^0.4.4; 
+                pragma solidity ^0.4.4;
                 pragma solidity 0.3.4; // disabled error: Compiler version must be greater that 0.4
             `,
         noIndent()
@@ -67,7 +80,7 @@ describe('Linter', () => {
                 /* solhint-disable compiler-gt-0_4 */
                 pragma solidity 0.3.4;
                 /* solhint-enable compiler-gt-0_4 */
-                pragma solidity 0.3.4; 
+                pragma solidity 0.3.4;
             `,
         noIndent()
       )
@@ -82,7 +95,7 @@ describe('Linter', () => {
                 /* solhint-disable compiler-gt-0_4 */
                 pragma solidity ^0.4.4;
                 /* solhint-enable compiler-gt-0_4 */
-                pragma solidity ^0.4.4; 
+                pragma solidity ^0.4.4;
             `,
         noIndent()
       )
@@ -96,7 +109,7 @@ describe('Linter', () => {
         `
                 /* solhint-disable */
                 pragma solidity ^0.4.4;
-                pragma solidity 0.3.4; 
+                pragma solidity 0.3.4;
             `,
         noIndent()
       )
@@ -110,7 +123,7 @@ describe('Linter', () => {
                 /* solhint-disable */
                 pragma solidity ^0.4.4;
                 /* solhint-enable */
-                pragma solidity ^0.4.4; 
+                pragma solidity ^0.4.4;
             `,
         noIndent()
       )


### PR DESCRIPTION
Similar to `solhint-disable-next-line`, `previous-line` disables linter errors on the line preceding the comment directive.

This is very useful when disabling `no-empty-blocks` errors, since it lets you put the directive inside the (empty) block, and not before it, where there may be comments (e.g. if it is a function).

Some examples from OpenZeppelin:

```
/**
 * @dev Validation of an executed purchase. Observe state and use revert statements to undo rollback when valid
 * conditions are not met.
 * @param beneficiary Address performing the token purchase
 * @param weiAmount Value in wei involved in the purchase
 */
function _postValidatePurchase(address beneficiary, uint256 weiAmount) internal view {
    // solhint-disable-previous-line no-empty-blocks
}
```

```
/**
 * @dev This contract should only be used by extending from it, deploying it as a base contract is disabled.
 */
constructor () internal {
  // solhint-disable-previous-line no-empty-blocks
} 
```