### PR TITLE
Fixed some comment directive tests.

### DIFF
--- a/test/comment-directives.js
+++ b/test/comment-directives.js
@@ -25,7 +25,7 @@ describe('Linter', () => {
       const report = linter.processStr(
         `
                 // solhint-disable-next-line
-                pragma solidity ^0.4.4; 
+                pragma solidity 0.3.4;
                 pragma solidity 0.3.4;
             `,
         noIndent()
@@ -38,7 +38,7 @@ describe('Linter', () => {
       const report = linter.processStr(
         `
                 /* solhint-disable-next-line */
-                pragma solidity ^0.4.4; 
+                pragma solidity 0.3.4;
                 pragma solidity 0.3.4;
             `,
         noIndent()


### PR DESCRIPTION
The assert statements checks for `assertErrorCount(report, 1)`, but the disabled line is `pragma solidity ^0.4.4;`, which triggers a _warning_ ('compiler version must be fixed'), not an error, so the test isn't really testing whether or not `disable-next-line` works.

This makes it so that both lines have an error.