### PR TITLE
Snake case now allows for a (single) leading underscore.

### DIFF
--- a/lib/common/identifier-naming.js
+++ b/lib/common/identifier-naming.js
@@ -20,7 +20,7 @@ module.exports = {
   },
 
   isUpperSnakeCase(text) {
-    return match(text, /[A-Z0-9]+[_A-Z0-9]*/)
+    return match(text, /_?[A-Z0-9]+[_A-Z0-9]*/)
   },
 
   isNotUpperSnakeCase(text) {

--- a/lib/common/identifier-naming.js
+++ b/lib/common/identifier-naming.js
@@ -20,7 +20,7 @@ module.exports = {
   },
 
   isUpperSnakeCase(text) {
-    return match(text, /_?[A-Z0-9]+[_A-Z0-9]*/)
+    return match(text, /_{0,2}[A-Z0-9]+[_A-Z0-9]*/)
   },
 
   isNotUpperSnakeCase(text) {

--- a/test/naming-rules.js
+++ b/test/naming-rules.js
@@ -59,8 +59,16 @@ describe('Linter', () => {
       assert.ok(report.messages[0].message.includes('Variable name'))
     })
 
-    it('should not raise var name error for constants', () => {
-      const code = contractWith('uint32 private constant D = 10;')
+    it('should not raise var name error for constants in snake case', () => {
+      const code = contractWith('uint32 private constant THE_CONSTANT = 10;')
+
+      const report = linter.processStr(code, noIndent())
+
+      assert.equal(report.errorCount, 0)
+    })
+
+    it('should not raise var name error for constants in snake case with leading underscore', () => {
+      const code = contractWith('uint32 private constant _THE_CONSTANT = 10;')
 
       const report = linter.processStr(code, noIndent())
 

--- a/test/naming-rules.js
+++ b/test/naming-rules.js
@@ -67,12 +67,29 @@ describe('Linter', () => {
       assert.equal(report.errorCount, 0)
     })
 
-    it('should not raise var name error for constants in snake case with leading underscore', () => {
+    it('should not raise var name error for constants in snake case with single leading underscore', () => {
       const code = contractWith('uint32 private constant _THE_CONSTANT = 10;')
 
       const report = linter.processStr(code, noIndent())
 
       assert.equal(report.errorCount, 0)
+    })
+
+    it('should not raise var name error for constants in snake case with double leading underscore', () => {
+      const code = contractWith('uint32 private constant __THE_CONSTANT = 10;')
+
+      const report = linter.processStr(code, noIndent())
+
+      assert.equal(report.errorCount, 0)
+    })
+
+    it('should not var name error for constants in snake case with more than two leading underscores', () => {
+      const code = contractWith('uint32 private constant ___THE_CONSTANT = 10;')
+
+      const report = linter.processStr(code, noIndent())
+
+      assert.equal(report.errorCount, 1)
+      assert.ok(report.messages[0].message.includes('SNAKE_CASE'))
     })
 
     it('should raise var name error for event arguments illegal styling', () => {

--- a/test/naming-rules.js
+++ b/test/naming-rules.js
@@ -83,7 +83,7 @@ describe('Linter', () => {
       assert.equal(report.errorCount, 0)
     })
 
-    it('should not var name error for constants in snake case with more than two leading underscores', () => {
+    it('should raise var name error for constants in snake case with more than two leading underscores', () => {
       const code = contractWith('uint32 private constant ___THE_CONSTANT = 10;')
 
       const report = linter.processStr(code, noIndent())


### PR DESCRIPTION
Related to #90.

Mixed case already allows for this, but uppercase snake case doesn't. The rationale is that the style rule should allow it, and then other (to be implemented) rules should decide whether or not its appropriate depending on some other conditions (e.g. allowed -or enforced- on `private` members, disallowed on `public`, etc.).