### PR TITLE
Add OpenZeppelin to list of users

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,12 +184,14 @@ Solhint is free to use and open-sourced. If you value our effort and feel like h
 
 [![Donate with Ethereum](https://en.cryptobadges.io/badge/micro/0xe8cdf02efd8ab0a490d7b2cb13553389c9bc932e)](https://en.cryptobadges.io/donate/0xe8cdf02efd8ab0a490d7b2cb13553389c9bc932e)
 
-## Who uses solhint?
-
+## Who uses Solhint?
+[<img src="https://avatars0.githubusercontent.com/u/20820676?s=200&v=4" width="75px" height="75px" alt="OpenZeppelin" title="OpenZeppelin" style="margin: 20px 20px 0 0" />](https://github.com/OpenZeppelin) 
 [<img src="https://avatars2.githubusercontent.com/u/28943015?s=200&v=4" width="75px" height="75px" alt="POA Network - Public EVM Sidechain" title="POA Network - Public EVM Sidechain" style="margin: 20px 20px 0 0" />](https://github.com/poanetwork) [<img src="https://avatars3.githubusercontent.com/u/24832717?s=200&v=4" width="75px" height="75px" alt="0x" title="0x" style="margin: 20px 20px 0 0" />](https://github.com/0xProject) [<img src="https://avatars1.githubusercontent.com/u/24954468?s=200&v=4" width="75px" height="75px" alt="GNOSIS" title="GNOSIS" style="margin: 20px 20px 0 0"/>](https://github.com/gnosis)
 
 ### Projects
 
+- OpenZeppelin:
+  - [openzeppelin-solidity](https://github.com/OpenZeppelin/openzeppelin-solidity)
 - POA Network - Public EVM Sidechain:
   - [Proof of Physical Address (PoPA)](https://github.com/poanetwork/poa-popa)
   - [Proof of Bank Account (PoBA)](https://github.com/poanetwork/poa-poba)


### PR DESCRIPTION
Closes #101 by adding OpenZeppelin's logo and link to github organization under the `Who uses Solhint?` section.