### PR TITLE
Better error when config file doesn't exist

### DIFF
--- a/lib/common/errors.js
+++ b/lib/common/errors.js
@@ -1,6 +1,7 @@
 class ConfigMissingError extends Error {
   constructor(configName) {
-    const message = `Failed to load config "${configName}" to extend from.`
+    let message = `Failed to load a solhint's config file.`
+    if (configName) message = `Failed to load config "${configName}" to extend from.`
     super(message)
   }
 }

--- a/lib/config/config-file.js
+++ b/lib/config/config-file.js
@@ -49,6 +49,9 @@ const loadConfig = () => {
 
   const explorer = cosmiconfig(moduleName, cosmiconfigOptions)
   const searchedFor = explorer.searchSync(appDirectory)
+  if (!searchedFor) {
+    throw new ConfigMissingError()
+  }
   return searchedFor.config || createEmptyConfig()
 }
 

--- a/solhint.js
+++ b/solhint.js
@@ -128,7 +128,7 @@ const readConfig = _.memoize(() => {
     config = loadConfig()
   } catch (e) {
     console.log(e.message)
-    process.exit(0)
+    process.exit(-1)
   }
 
   const configExcludeFiles = _.flatten(config.excludedFiles)

--- a/solhint.js
+++ b/solhint.js
@@ -128,7 +128,7 @@ const readConfig = _.memoize(() => {
     config = loadConfig()
   } catch (e) {
     console.log(e.message)
-    process.exit(-1)
+    process.exit(1)
   }
 
   const configExcludeFiles = _.flatten(config.excludedFiles)

--- a/test/common/errors.js
+++ b/test/common/errors.js
@@ -1,0 +1,22 @@
+const assert = require('assert')
+const { ConfigMissingError } = require('./../../lib/common/errors')
+
+describe('errors', () => {
+  it('should throw a ConfigMissingError and match the message', () => {
+    const ThrowError = () => {
+      throw new ConfigMissingError('config_example.json')
+    }
+
+    assert.throws(ThrowError, ConfigMissingError)
+    assert.throws(ThrowError, /Failed to load config "config_example.json" to extend from.$/)
+  })
+
+  it('should throw a ConfigMissingError and match the default message', () => {
+    const ThrowError = () => {
+      throw new ConfigMissingError()
+    }
+
+    assert.throws(ThrowError, ConfigMissingError)
+    assert.throws(ThrowError, /Failed to load a solhint's config file.$/)
+  })
+})


### PR DESCRIPTION
Closes #125 

- Exit code with -1 when .solhint.json doesn't exist
- Improve message when cannot read property 'config' of null, throw a custom error