### PR TITLE
Deprecate old compiler rules and disabling rules with falsy values

### DIFF
--- a/lib/config/config-validator.js
+++ b/lib/config/config-validator.js
@@ -1,3 +1,4 @@
+const _ = require('lodash')
 const ajv = require('../common/ajv')
 const configSchema = require('./config-schema')
 
@@ -38,12 +39,30 @@ const formatErrors = errors =>
     .map(message => `\t- ${message}.\n`)
     .join('')
 
+const deprecatedDisableValue = _.once(() => {
+  console.warn(
+    '[Solhint] Disabling rules with `false` or `0` is deprecated. Please use `"off"` instead.'
+  )
+})
+
 const validate = config => {
   validateSchema = validateSchema || ajv.compile(configSchema)
 
   if (!validateSchema(config)) {
     throw new Error(`Solhint configuration is invalid:\n${formatErrors(validateSchema.errors)}`)
   }
+
+  // show deprecated warning for rules that are configured with `false` or `0`
+  Object.keys(config.rules || {}).forEach(key => {
+    let severity = config.rules[key]
+    if (Array.isArray(severity)) {
+      severity = severity[0]
+    }
+
+    if (severity === false || severity === 0) {
+      deprecatedDisableValue()
+    }
+  })
 }
 
 module.exports = {

--- a/lib/config/config-validator.js
+++ b/lib/config/config-validator.js
@@ -1,3 +1,4 @@
+const chalk = require('chalk')
 const _ = require('lodash')
 const ajv = require('../common/ajv')
 const configSchema = require('./config-schema')
@@ -41,7 +42,9 @@ const formatErrors = errors =>
 
 const deprecatedDisableValue = _.once(() => {
   console.warn(
-    '[Solhint] Disabling rules with `false` or `0` is deprecated. Please use `"off"` instead.'
+    chalk.yellow(
+      '[Solhint] Warning: Disabling rules with `false` or `0` is deprecated. Please use `"off"` instead.'
+    )
   )
 })
 

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -1,3 +1,4 @@
+const chalk = require('chalk')
 const _ = require('lodash')
 const security = require('./security/index')
 const naming = require('./naming/index')
@@ -22,7 +23,16 @@ module.exports = function checkers(reporter, configVals, inputSrc, fileName) {
 
   const allRules = [...coreRules(meta), ...pluginsRules(plugins, meta)]
 
-  return allRules.filter(coreRule => ruleEnabled(coreRule, rules))
+  const enabledRules = allRules.filter(coreRule => ruleEnabled(coreRule, rules))
+
+  // show warnings for deprecated rules
+  for (const rule of enabledRules) {
+    if (rule.meta && rule.meta.deprecated) {
+      console.warn(chalk.yellow(`[solhint] Warning: rule '${rule.ruleId}' is deprecated.`))
+    }
+  }
+
+  return enabledRules
 }
 
 function coreRules(meta) {

--- a/lib/rules/security/compiler-fixed.js
+++ b/lib/rules/security/compiler-fixed.js
@@ -13,6 +13,8 @@ const meta = {
   recommended: true,
   defaultSetup: 'warn',
 
+  deprecated: true,
+
   schema: []
 }
 

--- a/lib/rules/security/compiler-gt-0_4.js
+++ b/lib/rules/security/compiler-gt-0_4.js
@@ -13,6 +13,8 @@ const meta = {
   recommended: true,
   defaultSetup: 'warn',
 
+  deprecated: true,
+
   schema: []
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -358,9 +358,9 @@
       "dev": true
     },
     "chalk": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -1111,8 +1111,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbols": {
       "version": "1.0.0",
@@ -3272,13 +3271,6 @@
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "requires": {
         "has-flag": "^3.0.0"
-      },
-      "dependencies": {
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-        }
       }
     },
     "table": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "ajv": "^6.6.1",
     "antlr4": "4.7.1",
+    "chalk": "^2.4.2",
     "commander": "2.18.0",
     "cosmiconfig": "^5.0.7",
     "eslint": "^5.6.0",

--- a/test/common/config-validator.js
+++ b/test/common/config-validator.js
@@ -38,4 +38,10 @@ describe('Config validator', () => {
     }
     assert.throws(() => validate(config), Error)
   })
+
+  it('should work with an empty config', () => {
+    const config = {}
+
+    validate(config) // should not throw
+  })
 })


### PR DESCRIPTION
Closes #123.
Closes #113.

This PR deprecates `0` and `false` as values for rules. It also deprecated the `compiler-gt-0_4` and `compiler-fixed` rules, in favor of `compiler-version`.

While there are some packages for showing deprecated warnings, I ended up using an ad hoc solution:
- [node-deprecate](https://github.com/brianc/node-deprecate/) has a bug in its latest version (it throws a TypeError)
- [nodejs-depd](https://github.com/dougwilson/nodejs-depd) seems to be more useful for libraries that deprecate public methods, which it's not the case for solhint. For example, it shows the line of the function that called the deprecated method.
- There's [util.deprecate](https://nodejs.org/api/util.html#util_util_deprecate_fn_msg_code) in the core modules, but I don't like how the message is shown.

So I just used `lodash.once` and `chalk`.