### PR TITLE
fix #133: do not trigger mark-callable-contracts on enums

### DIFF
--- a/lib/rules/security/mark-callable-contracts.js
+++ b/lib/rules/security/mark-callable-contracts.js
@@ -36,6 +36,15 @@ class MarkCallableContractsChecker {
     this.gatherNonContractNames(ctx)
   }
 
+  enterEnumDefinition(ctx) {
+    this.gatherNonContractNames(ctx)
+  }
+
+  enterEnumValue(ctx) {
+    const enumValue = ctx.getText()
+    this.nonContractNames.push(enumValue)
+  }
+
   exitStateVariableDeclaration(ctx) {
     const hasConstModifier = ctx.children.some(i => i.getText() === 'constant')
 

--- a/test/rules/security/mark-callable-contracts.js
+++ b/test/rules/security/mark-callable-contracts.js
@@ -87,4 +87,20 @@ describe('Linter - mark-callable-contracts', () => {
 
     assert.equal(report.warningCount, 0)
   })
+
+  it('should not return error for enum', () => {
+    const code = contractWith(`
+  enum Status { Initial }
+
+  function b() public view returns(Status) {
+    return Status.Initial;
+  }
+    `)
+
+    const report = linter.processStr(code, {
+      rules: { 'mark-callable-contracts': 'warn' }
+    })
+
+    assert.equal(report.warningCount, 0)
+  })
 })


### PR DESCRIPTION
I have added enum definitions and values to the `nonContractNames` list.