### PR TITLE
Fix data location "calldata" in external function parameters throws an "Unused variable" error

### DIFF
--- a/lib/common/utils.js
+++ b/lib/common/utils.js
@@ -1,23 +1,6 @@
 const fs = require('fs')
 const path = require('path')
 
-const getLocFromIndex = (text, index) => {
-  let line = 1
-  let column = 0
-  let i = 0
-  while (i < index) {
-    if (text[i] === '\n') {
-      line++
-      column = 0
-    } else {
-      column++
-    }
-    i++
-  }
-
-  return { line, column }
-}
-
 const walkSync = (dir, filelist = []) => {
   fs.readdirSync(dir).forEach(file => {
     filelist = fs.statSync(path.join(dir, file)).isDirectory()
@@ -28,6 +11,5 @@ const walkSync = (dir, filelist = []) => {
 }
 
 module.exports = {
-  getLocFromIndex,
   walkSync
 }

--- a/lib/rules/best-practises/no-unused-vars.js
+++ b/lib/rules/best-practises/no-unused-vars.js
@@ -75,9 +75,14 @@ class NoUnusedVarsChecker extends BaseChecker {
     const idNode = isCtxIdentifier ? ctx : findIdentifierInChildren(ctx)
     const funcScope = VarUsageScope.of(ctx)
 
-    if (idNode && funcScope) {
+    if (idNode && funcScope && !this._isCallDataStatement(ctx)) {
       funcScope.addVar(idNode, idNode.getText())
     }
+  }
+
+  _isCallDataStatement(ctx) {
+    const varName = ctx.children[1]
+    return varName && varName.getText() === 'calldata'
   }
 
   _trackVarUsage(ctx) {


### PR DESCRIPTION
Closes https://github.com/protofire/solhint/issues/96

The error occurs when using Truffle 5 and Solidity 0.5.0.

The PR removes an unused function called `getLocFromIndex` so the coverage will be increased.
If the `no-unused-vars` rule adds a variable to validate it, we check if the variable have the expression `calldata`. Also added some tests.

Regards