### PR TITLE
Patch for issue #137

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,9 +137,8 @@ Or disable all validations for a group of lines:
 ```javascript
   /* solhint-disable */
   function transferTo(address to, uint amount) public {
-          require(tx.origin == owner);
-          to.call.value(amount)();
-  
+    require(tx.origin == owner);
+    to.call.value(amount)();
   }
   /* solhint-enable */
 ```

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ format:
     "extends": "solhint:default",
     "plugins": [],
     "rules": {
-      "avoid-throw": false,
+      "const-name-snakecase": "off",
       "avoid-suicide": "error",
       "avoid-sha3": "warn",
       "avoid-tx-origin:": "warn"

--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ format:
     "rules": {
       "avoid-throw": false,
       "avoid-suicide": "error",
-      "avoid-sha3": "warn"
+      "avoid-sha3": "warn",
+      "avoid-tx-origin:": "warn"
     }
   }
 ```
@@ -123,19 +124,22 @@ Disable validation of fixed compiler version validation on current line:
 You can disable a rule for a group of lines:
 
 ```javascript
-  /* solhint-disable avoid-throw */
-  if (a > 1) {
-    throw;
+  /* solhint-disable avoid-tx-origin */
+  function transferTo(address to, uint amount) public {
+    require(tx.origin == owner);
+    to.call.value(amount)();
   }
-  /* solhint-enable avoid-throw */
+  /* solhint-enable avoid-tx-origin */
 ```
 
 Or disable all validations for a group of lines:
 
 ```javascript
   /* solhint-disable */
-  if (a > 1) {
-    throw;
+  function transferTo(address to, uint amount) public {
+          require(tx.origin == owner);
+          to.call.value(amount)();
+  
   }
   /* solhint-enable */
 ```


### PR DESCRIPTION
I rewrite the examples to use a more accurate avoid-tx-origin rule. I updated too the .solhint.json conf file given as example to change the deprecated 'false' to "off" value for removing rules, and i added a warning rule for avoid-tx-origin.