### PR TITLE
compiler-version should reject files without versions

### DIFF
--- a/lib/rules/security/compiler-version.js
+++ b/lib/rules/security/compiler-version.js
@@ -45,11 +45,9 @@ class CompilerVersionChecker extends BaseChecker {
   }
 
   SourceUnit(node) {
-    const hasPragmaDirectiveDef = node.children.filter(
-      curItem => curItem.type === 'PragmaDirective'
-    )
+    const hasPragmaDirectiveDef = node.children.some(curItem => curItem.type === 'PragmaDirective')
 
-    if (hasPragmaDirectiveDef.length === 0) {
+    if (!hasPragmaDirectiveDef) {
       this.warn(node, 'Compiler version must be declared ')
     }
   }

--- a/lib/rules/security/compiler-version.js
+++ b/lib/rules/security/compiler-version.js
@@ -44,6 +44,16 @@ class CompilerVersionChecker extends BaseChecker {
     this.requirement = (config && config.getString(ruleId, DEFAULT_SEMVER)) || DEFAULT_SEMVER
   }
 
+  SourceUnit(node) {
+    const hasPragmaDirectiveDef = node.children.filter(
+      curItem => curItem.type === 'PragmaDirective'
+    )
+
+    if (hasPragmaDirectiveDef.length === 0) {
+      this.warn(node, 'Compiler version must be declared ')
+    }
+  }
+
   PragmaDirective(node) {
     if (!semver.satisfies(semver.minVersion(node.value), this.requirement)) {
       this.warn(

--- a/test/rules/security/compiler-version.js
+++ b/test/rules/security/compiler-version.js
@@ -167,4 +167,24 @@ describe('Linter - compiler-version', () => {
 
     assert.equal(report.errorCount, 1)
   })
+
+  it(`should report compiler version error if pragma doesn't exist`, () => {
+    const report = linter.processStr('contract Foo {}', {
+      rules: { 'compiler-version': ['error', '^0.5.2'] }
+    })
+
+    assert.equal(report.errorCount, 1)
+  })
+
+  it(`should not report compiler version error if pragma exist`, () => {
+    const report = linter.processStr(
+      `pragma solidity 0.6.0;
+      contract Foo {}`,
+      {
+        rules: { 'compiler-version': ['error', '^0.6.0'] }
+      }
+    )
+
+    assert.equal(report.errorCount, 0)
+  })
 })


### PR DESCRIPTION
Closes #130 

Please see the base branch, is the `3.0`. 

#### Includes
- Added a validation in the `SourceUnit` function of the `CompilerVersionChecker` rule
- Check for the existence of the directive in the childrens
- Added a couple of tests

