### PR TITLE
test: no mark-callable-contracts for an event defined after a function

### DIFF
--- a/test/rules/security/mark-callable-contracts.js
+++ b/test/rules/security/mark-callable-contracts.js
@@ -72,6 +72,22 @@ describe('Linter - mark-callable-contracts', () => {
     assert.equal(report.warningCount, 0)
   })
 
+  it('should not return error for an event defined after function', () => {
+    const code = contractWith(`
+      function b() public {
+        emit UpdatedToken();
+      }
+
+      event UpdatedToken();
+    `)
+
+    const report = linter.processStr(code, {
+      rules: { 'mark-callable-contracts': 'warn' }
+    })
+
+    assert.equal(report.warningCount, 0)
+  })
+
   it('should not return error for constant', () => {
     const code = contractWith(`
   uint8 private constant TOKEN_DECIMALS = 15;


### PR DESCRIPTION
This adds the testcase mentioned in #173 to the new release.