### PR TITLE
Allow using solhint as a library and in the browser

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 const fs = require('fs')
-const parser = require('solidity-parser-antlr')
+const parser = require('@fvictorio/solidity-parser')
 const glob = require('glob')
 const ignore = require('ignore')
 const astParents = require('ast-parents')

--- a/package-lock.json
+++ b/package-lock.json
@@ -167,6 +167,11 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@fvictorio/solidity-parser": {
+      "version": "0.4.15",
+      "resolved": "https://registry.npmjs.org/@fvictorio/solidity-parser/-/solidity-parser-0.4.15.tgz",
+      "integrity": "sha512-DacgMagmysautS/MzbEmvgUOyoLxS6LSpMLFjINhUJFrG3OJXiihHMId6kOc08aiwlWHo+pd7C/z3ixm/gPPsQ=="
+    },
     "@stryker-mutator/api": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@stryker-mutator/api/-/api-2.3.0.tgz",
@@ -4014,10 +4019,6 @@
       "requires": {
         "is-fullwidth-code-point": "^2.0.0"
       }
-    },
-    "solidity-parser-antlr": {
-      "version": "git+https://github.com/fvictorio/solidity-parser-antlr.git#a237cb7417399eed129958ff89ea30ea87bd4b90",
-      "from": "git+https://github.com/fvictorio/solidity-parser-antlr.git#stable"
     },
     "source-map": {
       "version": "0.5.7",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "solhint",
   "version": "2.3.0",
   "description": "Solidity Code Linter",
-  "main": "solhint.js",
+  "main": "lib/index.js",
   "keywords": [
     "solidity",
     "linter",
@@ -43,7 +43,7 @@
     "js-yaml": "^3.12.0",
     "lodash": "^4.17.11",
     "semver": "^6.3.0",
-    "solidity-parser-antlr": "https://github.com/fvictorio/solidity-parser-antlr#stable"
+    "@fvictorio/solidity-parser": "^0.4.15"
   },
   "devDependencies": {
     "@stryker-mutator/core": "^2.3.0",


### PR DESCRIPTION
To test the "library" part: create an npm package, install solhint (you can use [yalc](https://github.com/whitecolor/yalc) for this), and use it like this:

```
const solhint = require('solhint')

solhint.parseStr('contract Foo {}')
```

To test the browser part, do the same thing but with a web app. For this to work the webpack configuration must have the [node](https://webpack.js.org/configuration/node/) option in true. If you use `create-react-app`, that is part of the configuration out of the box.