### PR TITLE
Validate rule schemas

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -78,14 +78,9 @@ const meta = {
   recommended: true,
   defaultSetup: [DEFAULT_SEVERITY, DEFAULT_INDENTS],
 
-  schema: [
-    {
-      type: 'array',
-      items: [{ type: 'integer' }],
-      uniqueItems: true,
-      minItems: 2
-    }
-  ]
+  schema: {
+    type: 'integer'
+  }
 }
 
 class IndentChecker {

--- a/lib/config.js
+++ b/lib/config.js
@@ -2,7 +2,7 @@ const _ = require('lodash')
 
 module.exports = {
   from(configVals) {
-    return _.assign(configVals, this)
+    return _.assign({ rules: {} }, configVals, this)
   },
 
   getNumberByPath(path, defaultValue) {

--- a/lib/rules/base-checker.js
+++ b/lib/rules/base-checker.js
@@ -1,8 +1,62 @@
+const chalk = require('chalk')
+const Ajv = require('ajv')
+
+const ruleConfigSchema = schema => {
+  const baseSchema = {
+    type: 'array',
+    items: [
+      {
+        enum: ['error', 'warn', 'off']
+      }
+    ],
+    minItems: 1
+  }
+
+  if (schema) {
+    baseSchema.items.push(schema)
+  }
+
+  return baseSchema
+}
+
 class BaseChecker {
   constructor(reporter, ruleId, meta) {
     this.reporter = reporter
     this.ruleId = ruleId
     this.meta = meta
+
+    if (!reporter) {
+      return
+    }
+
+    // validate user's configuration of the rule
+    const userConfig = reporter.config[ruleId]
+    if (userConfig) {
+      if (Array.isArray(userConfig)) {
+        const ajv = new Ajv()
+        const schema = ruleConfigSchema(meta.schema)
+        const validate = ajv.compile(schema)
+        if (!validate(userConfig)) {
+          const messages = validate.errors
+            .map(e => e.message)
+            .filter(x => x) // filter out possible missing messages
+            .map(x => `  ${x}`) // indent
+            .join('\n')
+
+          console.warn(
+            chalk.yellow(
+              `[solhint] Warning: invalid configuration for rule '${ruleId}':\n${messages}`
+            )
+          )
+        }
+      } else if (!['off', 'warn', 'error'].includes(userConfig)) {
+        console.warn(
+          chalk.yellow(
+            `[solhint] Warning: rule '${ruleId}' level is '${userConfig}'; should be one of "error", "warn" or "off"`
+          )
+        )
+      }
+    }
   }
 
   error(ctx, message, fix) {

--- a/lib/rules/best-practises/code-complexity.js
+++ b/lib/rules/best-practises/code-complexity.js
@@ -40,14 +40,7 @@ const meta = {
   recommended: false,
   defaultSetup: [DEFAULT_SEVERITY, DEFAULT_COMPLEXITY],
 
-  schema: [
-    {
-      type: 'array',
-      items: [{ type: 'integer' }],
-      uniqueItems: true,
-      minItems: 2
-    }
-  ]
+  schema: { type: 'integer' }
 }
 
 class CodeComplexityChecker extends BaseChecker {

--- a/lib/rules/best-practises/function-max-lines.js
+++ b/lib/rules/best-practises/function-max-lines.js
@@ -26,14 +26,10 @@ const meta = {
   recommended: false,
   defaultSetup: [DEFAULT_SEVERITY, DEFAULT_MAX_LINES_COUNT],
 
-  schema: [
-    {
-      type: 'array',
-      items: [{ type: 'integer' }],
-      uniqueItems: true,
-      minItems: 2
-    }
-  ]
+  schema: {
+    type: 'integer',
+    minimum: 1
+  }
 }
 
 class FunctionMaxLinesChecker extends BaseChecker {

--- a/lib/rules/best-practises/max-line-length.js
+++ b/lib/rules/best-practises/max-line-length.js
@@ -28,14 +28,7 @@ const meta = {
   recommended: false,
   defaultSetup: [DEFAULT_SEVERITY, DEFAULT_MAX_LINE_LENGTH],
 
-  schema: [
-    {
-      type: 'array',
-      items: [{ type: 'integer' }],
-      uniqueItems: true,
-      minItems: 2
-    }
-  ]
+  schema: { type: 'integer', minimum: 1 }
 }
 
 class MaxLineLengthChecker extends BaseChecker {

--- a/lib/rules/best-practises/max-states-count.js
+++ b/lib/rules/best-practises/max-states-count.js
@@ -42,14 +42,7 @@ const meta = {
   recommended: true,
   defaultSetup: [DEFAULT_SEVERITY, DEFAULT_MAX_STATES_COUNT],
 
-  schema: [
-    {
-      type: 'array',
-      items: [{ type: 'integer' }],
-      uniqueItems: true,
-      minItems: 2
-    }
-  ]
+  schema: { type: 'integer' }
 }
 
 class MaxStatesCountChecker extends BaseChecker {

--- a/lib/rules/best-practises/no-empty-blocks.js
+++ b/lib/rules/best-practises/no-empty-blocks.js
@@ -14,7 +14,7 @@ const meta = {
   recommended: true,
   defaultSetup: 'warn',
 
-  schema: []
+  schema: null
 }
 
 class NoEmptyBlocksChecker extends BaseChecker {

--- a/lib/rules/best-practises/no-unused-vars.js
+++ b/lib/rules/best-practises/no-unused-vars.js
@@ -17,7 +17,7 @@ const meta = {
   recommended: true,
   defaultSetup: 'warn',
 
-  schema: []
+  schema: null
 }
 
 class NoUnusedVarsChecker extends BaseChecker {

--- a/lib/rules/best-practises/payable-fallback.js
+++ b/lib/rules/best-practises/payable-fallback.js
@@ -28,7 +28,7 @@ const meta = {
   recommended: true,
   defaultSetup: 'warn',
 
-  schema: []
+  schema: null
 }
 
 class PayableFallbackChecker extends BaseChecker {

--- a/lib/rules/best-practises/reason-string.js
+++ b/lib/rules/best-practises/reason-string.js
@@ -45,23 +45,14 @@ const meta = {
   recommended: false,
   defaultSetup: [DEFAULT_SEVERITY, DEFAULT_OPTION],
 
-  schema: [
-    {
-      type: 'array',
-      items: [
-        {
-          properties: {
-            maxLength: {
-              type: 'integer'
-            }
-          },
-          additionalProperties: false
-        }
-      ],
-      uniqueItems: true,
-      minItems: 2
+  schema: {
+    type: 'object',
+    properties: {
+      maxLength: {
+        type: 'integer'
+      }
     }
-  ]
+  }
 }
 
 class ReasonStringChecker extends BaseChecker {

--- a/lib/rules/deprecations/constructor-syntax.js
+++ b/lib/rules/deprecations/constructor-syntax.js
@@ -13,7 +13,7 @@ const meta = {
   recommended: false,
   defaultSetup: 'warn',
 
-  schema: []
+  schema: null
 }
 
 class ConstructorSyntax extends BaseDeprecation {

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -11,7 +11,7 @@ const { validSeverityMap } = require('../config/config-validator')
 
 module.exports = function checkers(reporter, configVals, inputSrc, tokens, fileName) {
   const config = configObject.from(configVals)
-  const { rules = {} } = config
+  const { rules } = config
   const meta = {
     reporter,
     config,

--- a/lib/rules/miscellaneous/quotes.js
+++ b/lib/rules/miscellaneous/quotes.js
@@ -41,19 +41,10 @@ const meta = {
   recommended: true,
   defaultSetup: [DEFAULT_SEVERITY, DEFAULT_QUOTES_TYPE],
 
-  schema: [
-    {
-      type: 'array',
-      items: [
-        {
-          type: 'string',
-          enum: QUOTE_TYPES
-        }
-      ],
-      uniqueItems: true,
-      minItems: 2
-    }
-  ]
+  schema: {
+    type: 'string',
+    enum: QUOTE_TYPES
+  }
 }
 
 class QuotesChecker extends BaseChecker {

--- a/lib/rules/naming/const-name-snakecase.js
+++ b/lib/rules/naming/const-name-snakecase.js
@@ -14,7 +14,7 @@ const meta = {
   recommended: true,
   defaultSetup: 'warn',
 
-  schema: []
+  schema: null
 }
 
 class ConstNameSnakecaseChecker extends BaseChecker {

--- a/lib/rules/naming/contract-name-camelcase.js
+++ b/lib/rules/naming/contract-name-camelcase.js
@@ -14,7 +14,7 @@ const meta = {
   recommended: true,
   defaultSetup: 'warn',
 
-  schema: []
+  schema: null
 }
 
 class ContractNameCamelcaseChecker extends BaseChecker {

--- a/lib/rules/naming/event-name-camelcase.js
+++ b/lib/rules/naming/event-name-camelcase.js
@@ -14,7 +14,7 @@ const meta = {
   recommended: true,
   defaultSetup: 'warn',
 
-  schema: []
+  schema: null
 }
 
 class EventNameCamelcaseChecker extends BaseChecker {

--- a/lib/rules/naming/func-name-mixedcase.js
+++ b/lib/rules/naming/func-name-mixedcase.js
@@ -14,7 +14,7 @@ const meta = {
   recommended: true,
   defaultSetup: 'warn',
 
-  schema: []
+  schema: null
 }
 
 class FuncNameMixedcaseChecker extends BaseChecker {

--- a/lib/rules/naming/func-param-name-mixedcase.js
+++ b/lib/rules/naming/func-param-name-mixedcase.js
@@ -14,7 +14,7 @@ const meta = {
   recommended: false,
   defaultSetup: 'warn',
 
-  schema: []
+  schema: null
 }
 
 class FunctionParamNameMixedcaseChecker extends BaseChecker {

--- a/lib/rules/naming/modifier-name-mixedcase.js
+++ b/lib/rules/naming/modifier-name-mixedcase.js
@@ -14,7 +14,7 @@ const meta = {
   recommended: false,
   defaultSetup: 'warn',
 
-  schema: []
+  schema: null
 }
 
 class ModifierNameMixedcase extends BaseChecker {

--- a/lib/rules/naming/use-forbidden-name.js
+++ b/lib/rules/naming/use-forbidden-name.js
@@ -15,7 +15,7 @@ const meta = {
   recommended: true,
   defaultSetup: 'warn',
 
-  schema: []
+  schema: null
 }
 
 class UseForbiddenNameChecker extends BaseChecker {

--- a/lib/rules/naming/var-name-mixedcase.js
+++ b/lib/rules/naming/var-name-mixedcase.js
@@ -14,7 +14,7 @@ const meta = {
   recommended: true,
   defaultSetup: 'warn',
 
-  schema: []
+  schema: null
 }
 
 class VarNameMixedcaseChecker extends BaseChecker {

--- a/lib/rules/order/func-order.js
+++ b/lib/rules/order/func-order.js
@@ -31,7 +31,7 @@ const meta = {
   recommended: false,
   defaultSetup: 'warn',
 
-  schema: []
+  schema: null
 }
 
 class FuncOrderChecker extends BaseChecker {

--- a/lib/rules/order/imports-on-top.js
+++ b/lib/rules/order/imports-on-top.js
@@ -13,7 +13,7 @@ const meta = {
   recommended: true,
   defaultSetup: 'warn',
 
-  schema: []
+  schema: null
 }
 
 class ImportsOnTopChecker extends BaseChecker {

--- a/lib/rules/order/visibility-modifier-order.js
+++ b/lib/rules/order/visibility-modifier-order.js
@@ -27,7 +27,7 @@ const meta = {
   recommended: true,
   defaultSetup: 'warn',
 
-  schema: []
+  schema: null
 }
 
 class VisibilityModifierOrderChecker extends BaseChecker {

--- a/lib/rules/security/avoid-call-value.js
+++ b/lib/rules/security/avoid-call-value.js
@@ -13,7 +13,7 @@ const meta = {
   recommended: true,
   defaultSetup: 'warn',
 
-  schema: []
+  schema: null
 }
 
 class AvoidCallValueChecker extends BaseChecker {

--- a/lib/rules/security/avoid-low-level-calls.js
+++ b/lib/rules/security/avoid-low-level-calls.js
@@ -22,7 +22,7 @@ const meta = {
   recommended: true,
   defaultSetup: 'warn',
 
-  schema: []
+  schema: null
 }
 
 class AvoidLowLevelCallsChecker extends BaseChecker {

--- a/lib/rules/security/avoid-sha3.js
+++ b/lib/rules/security/avoid-sha3.js
@@ -14,7 +14,7 @@ const meta = {
   defaultSetup: 'warn',
   fixable: true,
 
-  schema: []
+  schema: null
 }
 
 class AvoidSha3Checker extends BaseChecker {

--- a/lib/rules/security/avoid-suicide.js
+++ b/lib/rules/security/avoid-suicide.js
@@ -13,7 +13,7 @@ const meta = {
   recommended: true,
   defaultSetup: 'warn',
 
-  schema: []
+  schema: null
 }
 
 class AvoidSuicideChecker extends BaseChecker {

--- a/lib/rules/security/avoid-throw.js
+++ b/lib/rules/security/avoid-throw.js
@@ -14,7 +14,7 @@ const meta = {
   defaultSetup: 'warn',
   fixable: true,
 
-  schema: []
+  schema: null
 }
 
 class AvoidThrowChecker extends BaseChecker {

--- a/lib/rules/security/avoid-tx-origin.js
+++ b/lib/rules/security/avoid-tx-origin.js
@@ -13,7 +13,7 @@ const meta = {
   recommended: true,
   defaultSetup: 'warn',
 
-  schema: []
+  schema: null
 }
 
 class AvoidTxOriginChecker extends BaseChecker {

--- a/lib/rules/security/check-send-result.js
+++ b/lib/rules/security/check-send-result.js
@@ -30,7 +30,7 @@ const meta = {
   recommended: true,
   defaultSetup: 'warn',
 
-  schema: []
+  schema: null
 }
 
 class CheckSendResultChecker extends BaseChecker {

--- a/lib/rules/security/compiler-version.js
+++ b/lib/rules/security/compiler-version.js
@@ -27,14 +27,9 @@ const meta = {
   recommended: true,
   defaultSetup: [DEFAULT_SEVERITY, DEFAULT_SEMVER],
 
-  schema: [
-    {
-      type: 'array',
-      items: [{ type: 'string' }],
-      uniqueItems: true,
-      minItems: 2
-    }
-  ]
+  schema: {
+    type: 'string'
+  }
 }
 
 class CompilerVersionChecker extends BaseChecker {

--- a/lib/rules/security/func-visibility.js
+++ b/lib/rules/security/func-visibility.js
@@ -27,7 +27,7 @@ const meta = {
   recommended: true,
   defaultSetup: 'warn',
 
-  schema: []
+  schema: null
 }
 
 class FuncVisibilityChecker extends BaseChecker {

--- a/lib/rules/security/mark-callable-contracts.js
+++ b/lib/rules/security/mark-callable-contracts.js
@@ -31,7 +31,7 @@ const meta = {
   recommended: true,
   defaultSetup: 'warn',
 
-  schema: []
+  schema: null
 }
 
 class MarkCallableContractsChecker {

--- a/lib/rules/security/multiple-sends.js
+++ b/lib/rules/security/multiple-sends.js
@@ -16,7 +16,7 @@ const meta = {
   recommended: true,
   defaultSetup: 'warn',
 
-  schema: []
+  schema: null
 }
 
 class MultipleSendsChecker extends BaseChecker {

--- a/lib/rules/security/no-complex-fallback.js
+++ b/lib/rules/security/no-complex-fallback.js
@@ -14,7 +14,7 @@ const meta = {
   recommended: true,
   defaultSetup: 'warn',
 
-  schema: []
+  schema: null
 }
 
 class NoComplexFallbackChecker extends BaseChecker {

--- a/lib/rules/security/no-inline-assembly.js
+++ b/lib/rules/security/no-inline-assembly.js
@@ -13,7 +13,7 @@ const meta = {
   recommended: true,
   defaultSetup: 'warn',
 
-  schema: []
+  schema: null
 }
 
 class NoInlineAssemblyChecker extends BaseChecker {

--- a/lib/rules/security/not-rely-on-block-hash.js
+++ b/lib/rules/security/not-rely-on-block-hash.js
@@ -13,7 +13,7 @@ const meta = {
   recommended: true,
   defaultSetup: 'warn',
 
-  schema: []
+  schema: null
 }
 
 class NotRelyOnBlockHashChecker extends BaseChecker {

--- a/lib/rules/security/not-rely-on-time.js
+++ b/lib/rules/security/not-rely-on-time.js
@@ -13,7 +13,7 @@ const meta = {
   recommended: true,
   defaultSetup: 'warn',
 
-  schema: []
+  schema: null
 }
 
 class NotRelyOnTimeChecker extends BaseChecker {

--- a/lib/rules/security/reentrancy.js
+++ b/lib/rules/security/reentrancy.js
@@ -43,7 +43,7 @@ const meta = {
   recommended: true,
   defaultSetup: 'warn',
 
-  schema: []
+  schema: null
 }
 
 class ReentrancyChecker extends BaseChecker {

--- a/lib/rules/security/state-visibility.js
+++ b/lib/rules/security/state-visibility.js
@@ -13,7 +13,7 @@ const meta = {
   recommended: true,
   defaultSetup: 'warn',
 
-  schema: []
+  schema: null
 }
 
 class StateVisibilityChecker extends BaseChecker {


### PR DESCRIPTION
The schemas of the rules configurations now only represent the configuration itself (meaning, the second element of the array when setting a rule). Then, `base-checker` validates that the schema is correct. If it's not, **only a warning is emitted**, execution is not interrupted.

Lot of files to review here, but the important part is in `base-checker`.