### PR TITLE
New call syntax

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -168,9 +168,9 @@
       }
     },
     "@solidity-parser/parser": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.5.2.tgz",
-      "integrity": "sha512-uRyvnvVYmgNmTBpWDbBsH/0kPESQhQpEc4KsvMRLVzFJ1o1s0uIv0Y6Y9IB5vI1Dwz2CbS4X/y4Wyw/75cTFnQ=="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.6.0.tgz",
+      "integrity": "sha512-RiJXfS22frulogcfQCFhbKrd5ATu6P4tYUv/daChiIh6VHyKQ1kkVZVfX6aP7c2YGU/Bf9RwGNKdwLjfpaoqYQ=="
     },
     "@stryker-mutator/api": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "author": "Ilya Drabenia <ilya.drobenya@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@solidity-parser/parser": "^0.5.2",
+    "@solidity-parser/parser": "^0.6.0",
     "ajv": "^6.6.1",
     "antlr4": "4.7.1",
     "ast-parents": "0.0.1",

--- a/test/rules/best-practises/no-unused-vars.js
+++ b/test/rules/best-practises/no-unused-vars.js
@@ -26,6 +26,8 @@ describe('Linter - no-unused-vars', () => {
     contractWith('function a() public returns (uint c) { return 1; }'),
     contractWith('function a(uint d) public returns (uint c) { }'),
     contractWith('function a(uint a, uint c) public returns (uint c);'),
+    contractWith('function a(uint amount) public { foo.deposit{value: amount}(); }'),
+    contractWith('function a(uint amount) public { foo.deposit({value: amount}); }'),
     contractWith(
       multiLine(
         'function a(address a) internal {',


### PR DESCRIPTION
Fix `no-unused-vars` problem when the `recipient.call{value: amount}()` syntax is used. See comment: https://github.com/protofire/solhint/issues/170#issuecomment-614281420