### PR TITLE
Better error handling when loading plugins

### DIFF
--- a/docs/writing-plugins.md
+++ b/docs/writing-plugins.md
@@ -45,6 +45,8 @@ class NoFoosAllowed {
     }
   }
 }
+
+module.exports = [NoFoosAllowed]
 ```
 
 _You can experiment with an AST by going to [AST explorer](https://astexplorer.net/) and selecting "Solidity" as the

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -69,6 +69,15 @@ function loadPlugin(pluginName, { reporter, config, inputSrc, fileName }) {
     process.exit(1)
   }
 
+  if (!Array.isArray(plugins)) {
+    console.warn(
+      chalk.yellow(
+        `[solhint] Warning: Plugin solhint-plugin-${pluginName} doesn't export an array of rules. Ignoring it.`
+      )
+    )
+    return []
+  }
+
   return plugins.map(Plugin => new Plugin(reporter, config, inputSrc, fileName)).map(plugin => {
     plugin.ruleId = `${pluginName}/${plugin.ruleId}`
     return plugin

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -57,7 +57,17 @@ function coreRules(meta) {
 }
 
 function loadPlugin(pluginName, { reporter, config, inputSrc, fileName }) {
-  const plugins = require(`solhint-plugin-${pluginName}`)
+  let plugins
+  try {
+    plugins = require(`solhint-plugin-${pluginName}`)
+  } catch (e) {
+    console.error(
+      chalk.red(
+        `[solhint] Error: Could not load solhint-plugin-${pluginName}, make sure it's installed..`
+      )
+    )
+    process.exit(1)
+  }
 
   return plugins.map(Plugin => new Plugin(reporter, config, inputSrc, fileName)).map(plugin => {
     plugin.ruleId = `${pluginName}/${plugin.ruleId}`


### PR DESCRIPTION
Closes #207

Show an error message and exit if the plugin doesn't exist. Show a warning when a plugin doesn't export an array.