### PR TITLE
Emit unused var warning for params of empty functions

### DIFF
--- a/lib/rules/best-practises/no-unused-vars.js
+++ b/lib/rules/best-practises/no-unused-vars.js
@@ -27,14 +27,15 @@ class NoUnusedVarsChecker extends BaseChecker {
 
   FunctionDefinition(node) {
     const funcWithoutBlock = isFuncWithoutBlock(node)
-    const emptyBlock = isEmptyBlock(node)
 
-    if (!ignoreWhen(funcWithoutBlock, emptyBlock)) {
-      VarUsageScope.activate(node)
-      node.parameters.filter(parameter => parameter.name).forEach(parameter => {
-        this._addVariable(parameter)
-      })
+    if (funcWithoutBlock) {
+      return
     }
+
+    VarUsageScope.activate(node)
+    node.parameters.filter(parameter => parameter.name).forEach(parameter => {
+      this._addVariable(parameter)
+    })
   }
 
   VariableDeclarationStatement(node) {
@@ -142,16 +143,8 @@ class VarUsageScope {
   }
 }
 
-function isEmptyBlock(node) {
-  return _.size(node.body && node.body.statements) === 0
-}
-
 function isFuncWithoutBlock(node) {
   return node.body === null
-}
-
-function ignoreWhen(...args) {
-  return _.some(args)
 }
 
 function findParentType(node, type) {

--- a/test/rules/best-practises/no-unused-vars.js
+++ b/test/rules/best-practises/no-unused-vars.js
@@ -7,11 +7,12 @@ describe('Linter - no-unused-vars', () => {
     contractWith('function a(uint a, uint b) public { b += 1; }'),
     funcWith('uint a = 0;'),
     funcWith('var (a) = 1;'),
-    contractWith('function a(uint a, uint b) public { uint c = a + b; }')
+    contractWith('function a(uint a, uint b) public { uint c = a + b; }'),
+    contractWith('function foo(uint a) public {}')
   ]
 
-  UNUSED_VARS.forEach(curData =>
-    it(`should raise warn for vars ${label(curData)}`, () => {
+  UNUSED_VARS.forEach((curData, i) =>
+    it(`should raise warn for unused vars (${i})`, () => {
       const report = linter.processStr(curData, {
         rules: { 'no-unused-vars': 'warn' }
       })
@@ -24,7 +25,6 @@ describe('Linter - no-unused-vars', () => {
   const USED_VARS = [
     contractWith('function a(uint a) public { uint b = bytes32(a); b += 1; }'),
     contractWith('function a() public returns (uint c) { return 1; }'),
-    contractWith('function a(uint d) public returns (uint c) { }'),
     contractWith('function a(uint a, uint c) public returns (uint c);'),
     contractWith('function a(uint amount) public { foo.deposit{value: amount}(); }'),
     contractWith('function a(uint amount) public { foo.deposit({value: amount}); }'),
@@ -63,8 +63,8 @@ describe('Linter - no-unused-vars', () => {
     )
   ]
 
-  USED_VARS.forEach(curData =>
-    it(`should not raise warn for vars ${label(curData)}`, () => {
+  USED_VARS.forEach((curData, i) =>
+    it(`should not raise warn for vars (${i})`, () => {
       const report = linter.processStr(curData, {
         rules: { 'no-unused-vars': 'warn' }
       })
@@ -86,11 +86,4 @@ function withdrawalAllowed(address) public view override returns (bool) {
 
     assertNoWarnings(report)
   })
-
-  function label(data) {
-    const items = data.split('\n')
-    const lastItemIndex = items.length - 1
-    const labelIndex = Math.floor(lastItemIndex / 5) * 4
-    return items[labelIndex]
-  }
 })


### PR DESCRIPTION
Closes #136.

It seems like this was done by design? But it doesn't make a lot of sense to me. It _does_ make sense for abstract functions though. Maybe this was the way it was done before that was supported? @patitonar what do you think?

Also, this is a minor breaking change, although I would argue that the difference between fixing a bug and introducing a breaking change is in the eye of the beholder.