### PR TITLE
Deprecate func-order and add ordering rule

### DIFF
--- a/lib/common/ast-types.js
+++ b/lib/common/ast-types.js
@@ -6,7 +6,17 @@ function isFunctionDefinition(node) {
   return node.type === 'FunctionDefinition'
 }
 
+function isStructDefinition(node) {
+  return node.type === 'StructDefinition'
+}
+
+function isEnumDefinition(node) {
+  return node.type === 'EnumDefinition'
+}
+
 module.exports = {
   isFallbackFunction,
-  isFunctionDefinition
+  isFunctionDefinition,
+  isStructDefinition,
+  isEnumDefinition
 }

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -9,8 +9,11 @@ const miscellaneous = require('./miscellaneous/index')
 const configObject = require('./../config')
 const { validSeverityMap } = require('../config/config-validator')
 
-const notifyRuleDeprecated = _.memoize(ruleId => {
-  console.warn(chalk.yellow(`[solhint] Warning: rule '${ruleId}' is deprecated.`))
+const notifyRuleDeprecated = _.memoize((ruleId, deprecationMessage) => {
+  const message = deprecationMessage
+    ? `[solhint] Warning: rule '${ruleId}' is deprecated, ${deprecationMessage}.`
+    : `[solhint] Warning: rule '${ruleId}' is deprecated.`
+  console.warn(chalk.yellow(message))
 })
 
 const notifyRuleDoesntExist = _.memoize(ruleId => {
@@ -36,7 +39,7 @@ module.exports = function checkers(reporter, configVals, inputSrc, tokens, fileN
   // show warnings for deprecated rules
   for (const rule of enabledRules) {
     if (rule.meta && rule.meta.deprecated) {
-      notifyRuleDeprecated(rule.ruleId)
+      notifyRuleDeprecated(rule.ruleId, rule.meta.deprecationMessage)
     }
   }
 

--- a/lib/rules/order/index.js
+++ b/lib/rules/order/index.js
@@ -1,11 +1,13 @@
 const FuncOrderChecker = require('./func-order')
 const ImportsOnTopChecker = require('./imports-on-top')
 const VisibilityModifierOrderChecker = require('./visibility-modifier-order')
+const OrderingChecker = require('./ordering')
 
 module.exports = function order(reporter, tokens) {
   return [
     new FuncOrderChecker(reporter),
     new ImportsOnTopChecker(reporter),
-    new VisibilityModifierOrderChecker(reporter, tokens)
+    new VisibilityModifierOrderChecker(reporter, tokens),
+    new OrderingChecker(reporter)
   ]
 }

--- a/lib/rules/order/ordering.js
+++ b/lib/rules/order/ordering.js
@@ -1,55 +1,53 @@
 const BaseChecker = require('./../base-checker')
 const { isFallbackFunction } = require('../../common/ast-types')
 
-const ruleId = 'func-order'
+const ruleId = 'ordering'
 const meta = {
   type: 'order',
 
   docs: {
-    description: `Function order is incorrect.`,
+    description: `Check order of elements in file and inside each contract, according to the style guide`,
     category: 'Style Guide Rules',
     examples: {
-      good: [
-        {
-          description: 'Constructor is placed before other functions',
-          code: require('../../../test/fixtures/order/func-order-constructor-first')
-        }
-      ],
-      bad: [
-        {
-          description: 'Constructor is placed after other functions',
-          code: require('../../../test/fixtures/order/func-order-constructor-not-first')
-        }
-      ]
+      good: require('../../../test/fixtures/order/ordering-correct'),
+      bad: require('../../../test/fixtures/order/ordering-incorrect')
     }
   },
 
   isDefault: false,
-  deprecated: true,
-  deprecationMessage: "use 'ordering' instead",
   recommended: false,
   defaultSetup: 'warn',
 
   schema: null
 }
 
-class FuncOrderChecker extends BaseChecker {
+class OrderingChecker extends BaseChecker {
   constructor(reporter) {
     super(reporter, ruleId, meta)
+  }
+
+  SourceUnit(node) {
+    const children = node.children
+
+    this.checkOrder(children, sourceUnitPartOrder)
   }
 
   ContractDefinition(node) {
     const children = node.subNodes
 
+    this.checkOrder(children, contractPartOrder)
+  }
+
+  checkOrder(children, orderFunction) {
     if (children.length === 0) {
       return
     }
 
     let maxChild = children[0]
-    let [maxComparisonValue, maxLabel] = getComparisonValueAndLabel(children[0])
+    let [maxComparisonValue, maxLabel] = orderFunction(children[0])
 
     for (let i = 1; i < children.length; i++) {
-      const [comparisonValue, label] = getComparisonValueAndLabel(children[i])
+      const [comparisonValue, label] = orderFunction(children[i])
       if (comparisonValue < maxComparisonValue) {
         this.report(children[i], maxChild, label, maxLabel)
         return
@@ -77,7 +75,37 @@ function isTypeDeclaration(node) {
   return ['StructDefinition', 'EnumDefinition'].includes(node.type)
 }
 
-function getComparisonValueAndLabel(node) {
+function sourceUnitPartOrder(node) {
+  if (node.type === 'PragmaDirective') {
+    return [0, 'pragma directive']
+  }
+
+  if (node.type === 'ImportDirective') {
+    return [10, 'import directive']
+  }
+
+  if (node.type === 'EnumDefinition' || node.type === 'StructDefinition') {
+    return [20, 'type definition']
+  }
+
+  if (node.type === 'ContractDefinition') {
+    if (node.kind === 'interface') {
+      return [30, 'interface']
+    }
+
+    if (node.kind === 'library') {
+      return [40, 'library definition']
+    }
+
+    if (node.kind === 'contract') {
+      return [50, 'contract definition']
+    }
+  }
+
+  throw new Error('Unrecognized source unit part, please report this issue')
+}
+
+function contractPartOrder(node) {
   if (isTypeDeclaration(node)) {
     let label
     if (node.type === 'StructDefinition') {
@@ -129,4 +157,4 @@ function getComparisonValueAndLabel(node) {
   throw new Error('Unrecognized contract part, please report this issue')
 }
 
-module.exports = FuncOrderChecker
+module.exports = OrderingChecker

--- a/test/fixtures/order/ordering-correct.js
+++ b/test/fixtures/order/ordering-correct.js
@@ -1,0 +1,58 @@
+module.exports = [
+  {
+    description: 'All units are in order',
+    code: `
+pragma solidity ^0.6.0;
+
+import "./some/library.sol";
+import "./some/other-library.sol";
+
+enum MyEnum {
+  Foo,
+  Bar
+}
+
+struct MyStruct {
+  uint x;
+  uint y;
+}
+
+interface IBox {
+  function getValue() public;
+  function setValue(uint) public;
+}
+
+library MyLibrary {
+  function add(uint a, uint b, uint c) public returns (uint) {
+    return a + b + c;
+  }
+}
+
+contract MyContract {
+  struct InnerStruct {
+    bool flag;
+  }
+
+  enum InnerEnum {
+    A, B, C
+  }
+
+  uint public x;
+  uint public y;
+
+  event MyEvent(address a);
+
+  constructor () public {}
+
+  fallback () external {}
+
+  function myExternalFunction() external {}
+  function myExternalConstFunction() external const {}
+  function myPublicFunction() public {}
+  function myPublicConstFunction() public const {}
+  function myInternalFunction() internal {}
+  function myPrivateFunction() private {}
+}
+`
+  }
+]

--- a/test/fixtures/order/ordering-incorrect.js
+++ b/test/fixtures/order/ordering-incorrect.js
@@ -1,0 +1,28 @@
+module.exports = [
+  {
+    description: 'State variable declaration after function',
+    code: `
+  contract MyContract {
+    function foo() public {}
+
+    uint a;
+  }
+`
+  },
+  {
+    description: 'Library after contract',
+    code: `
+  contract MyContract {}
+
+  library MyLibrary {}
+`
+  },
+  {
+    description: 'Interface after library',
+    code: `
+  library MyLibrary {}
+
+  interface MyInterface {}
+`
+  }
+]

--- a/test/rules/order/ordering.js
+++ b/test/rules/order/ordering.js
@@ -1,0 +1,161 @@
+const assert = require('assert')
+const linter = require('./../../../lib/index')
+const contractWith = require('./../../common/contract-builder').contractWith
+const correctExamples = require('../../fixtures/order/ordering-correct')
+const incorrectExamples = require('../../fixtures/order/ordering-incorrect')
+
+describe('Linter - ordering', () => {
+  describe('correct examples', () => {
+    correctExamples.forEach(({ code, description }) => {
+      it(description, () => {
+        const report = linter.processStr(code, {
+          rules: { ordering: 'error' }
+        })
+
+        assert.equal(report.errorCount, 0)
+      })
+    })
+  })
+
+  describe('incorrect examples', () => {
+    incorrectExamples.forEach(({ code, description }) => {
+      it(description, () => {
+        const report = linter.processStr(code, {
+          rules: { ordering: 'error' }
+        })
+
+        assert.equal(report.errorCount, 1)
+      })
+    })
+  })
+
+  it('should raise incorrect function order error I', () => {
+    const code = contractWith(`
+                function b() private {}
+                function () public payable {}
+            `)
+
+    const report = linter.processStr(code, {
+      rules: { ordering: 'error' }
+    })
+
+    assert.equal(report.errorCount, 1)
+    assert.ok(report.messages[0].message.includes('Function order is incorrect'))
+  })
+
+  it('should raise incorrect function order error for external constant funcs', () => {
+    const code = contractWith(`
+                function b() external pure {}
+                function c() external {}
+            `)
+
+    const report = linter.processStr(code, {
+      rules: { ordering: 'error' }
+    })
+
+    assert.equal(report.errorCount, 1)
+    assert.ok(report.messages[0].message.includes('Function order is incorrect'))
+  })
+
+  it('should raise incorrect function order error for public constant funcs', () => {
+    const code = contractWith(`
+              function b() public pure {}
+              function c() public {}
+          `)
+
+    const report = linter.processStr(code, {
+      rules: { ordering: 'error' }
+    })
+
+    assert.equal(report.errorCount, 1)
+    assert.ok(report.messages[0].message.includes('Function order is incorrect'))
+  })
+
+  it('should raise incorrect function order error for internal function', () => {
+    const code = contractWith(`
+                function c() internal {}
+                function b() external view {}
+            `)
+
+    const report = linter.processStr(code, {
+      rules: { ordering: 'error' }
+    })
+
+    assert.equal(report.errorCount, 1)
+    assert.ok(report.messages[0].message.includes('Function order is incorrect'))
+  })
+
+  it('should not raise incorrect function order error', () => {
+    const code = contractWith(`
+                function A() public {}
+                function () public payable {}
+            `)
+
+    const report = linter.processStr(code, {
+      rules: { ordering: 'error' }
+    })
+
+    assert.equal(report.errorCount, 0)
+  })
+
+  it('should not raise incorrect function order error I', () => {
+    const code = require('../../fixtures/order/func-order-constructor-first')
+
+    const report = linter.processStr(code, {
+      rules: { ordering: 'error' }
+    })
+
+    assert.equal(report.errorCount, 0)
+  })
+
+  it('should raise incorrect function order error', () => {
+    const code = require('../../fixtures/order/func-order-constructor-not-first')
+
+    const report = linter.processStr(code, {
+      rules: { ordering: 'error' }
+    })
+    assert.equal(report.errorCount, 1)
+    assert.ok(report.messages[0].message.includes('Function order is incorrect'))
+  })
+
+  it('should not raise error when external const goes before public ', () => {
+    const code = contractWith(`
+                function a() external view {}
+                function b() public {}
+            `)
+
+    const report = linter.processStr(code, {
+      rules: { ordering: 'error' }
+    })
+
+    assert.equal(report.errorCount, 0)
+  })
+
+  it('should raise error for enum after contract', () => {
+    const code = `
+      contract Foo {}
+
+      enum MyEnum { A, B }
+    `
+
+    const report = linter.processStr(code, {
+      rules: { ordering: 'error' }
+    })
+
+    assert.equal(report.errorCount, 1)
+  })
+
+  it('should raise error for enum after function', () => {
+    const code = contractWith(`
+      function foo() public {}
+
+      enum MyEnum { A, B }
+    `)
+
+    const report = linter.processStr(code, {
+      rules: { ordering: 'error' }
+    })
+
+    assert.equal(report.errorCount, 1)
+  })
+})


### PR DESCRIPTION
Closes #121.

The style guide has a suggested order both at the file level (pragmas before imports, imports before libraries, etc.) and at the contract level (state variables before functions, etc.). To better reflect this, I created a `ordering` rule and deprecated `func-order`.

The implementation looks tricky but it isn't that crazy: I assign each node a value for their relative order, and then check each one in the order they appear. If some node with an ordering value of, say, 30, appears after a node with ordering of 40, then there's a problem.

Also notice that to simplify things the rule stops at the first error it finds.