### PR TITLE
implement strict mode for private-vars-leading-underscore

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -10,6 +10,11 @@ module.exports = {
     return _.isNumber(configVal) && configVal > 0 ? configVal : defaultValue
   },
 
+  getBooleanByPath(path, defaultValue) {
+    const configVal = _.get(this, path)
+    return _.isBoolean(configVal) ? configVal : defaultValue
+  },
+
   getStringByPath(path, defaultValue) {
     const configVal = _.get(this, path)
     return _.isString(configVal) ? configVal : defaultValue
@@ -21,6 +26,10 @@ module.exports = {
 
   getObjectPropertyNumber(ruleName, ruleProperty, defaultValue) {
     return this.getNumberByPath(`rules["${ruleName}"][1][${ruleProperty}]`, defaultValue)
+  },
+
+  getObjectPropertyBoolean(ruleName, ruleProperty, defaultValue) {
+    return this.getBooleanByPath(`rules["${ruleName}"][1][${ruleProperty}]`, defaultValue)
   },
 
   getString(ruleName, defaultValue) {

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -58,7 +58,7 @@ function coreRules(meta) {
     ...bestPractises(reporter, config, inputSrc),
     ...deprecations(reporter),
     ...miscellaneous(reporter, config, tokens),
-    ...naming(reporter),
+    ...naming(reporter, config),
     ...order(reporter, tokens),
     ...security(reporter, config, inputSrc)
   ]

--- a/lib/rules/naming/index.js
+++ b/lib/rules/naming/index.js
@@ -8,7 +8,7 @@ const PrivateVarsLeadingUnderscore = require('./private-vars-leading-underscore'
 const UseForbiddenNameChecker = require('./use-forbidden-name')
 const VarNameMixedcaseChecker = require('./var-name-mixedcase')
 
-module.exports = function checkers(reporter) {
+module.exports = function checkers(reporter, config) {
   return [
     new ConstNameSnakecaseChecker(reporter),
     new ContractNameCamelcaseChecker(reporter),
@@ -16,7 +16,7 @@ module.exports = function checkers(reporter) {
     new FuncNameMixedcaseChecker(reporter),
     new FuncParamNameMixedcaseChecker(reporter),
     new ModifierNameMixedcaseChecker(reporter),
-    new PrivateVarsLeadingUnderscore(reporter),
+    new PrivateVarsLeadingUnderscore(reporter, config),
     new UseForbiddenNameChecker(reporter),
     new VarNameMixedcaseChecker(reporter)
   ]

--- a/lib/rules/naming/private-vars-leading-underscore.js
+++ b/lib/rules/naming/private-vars-leading-underscore.js
@@ -1,5 +1,10 @@
 const BaseChecker = require('./../base-checker')
 const naming = require('./../../common/identifier-naming')
+const { severityDescription } = require('../../doc/utils')
+
+const DEFAULT_SEVERITY = 'warn'
+const DEFAULT_STRICTNESS = false
+const DEFAULT_OPTION = { strict: DEFAULT_STRICTNESS }
 
 const ruleId = 'private-vars-leading-underscore'
 const meta = {
@@ -7,19 +12,39 @@ const meta = {
 
   docs: {
     description: 'Private and internal names must start with a single underscore.',
-    category: 'Style Guide Rules'
+    category: 'Style Guide Rules',
+    options: [
+      {
+        description: severityDescription,
+        default: DEFAULT_SEVERITY
+      },
+      {
+        description:
+          'A JSON object with a single property "strict" specifying if the rule should not apply to non state variables. Default: { strict: false }.',
+        default: JSON.stringify(DEFAULT_OPTION)
+      }
+    ]
   },
 
   isDefault: false,
   recommended: false,
-  defaultSetup: 'warn',
+  defaultSetup: [DEFAULT_SEVERITY, DEFAULT_OPTION],
 
-  schema: null
+  schema: {
+    type: 'object',
+    properties: {
+      strict: {
+        type: 'boolean'
+      }
+    }
+  }
 }
 
 class PrivateVarsLeadingUnderscoreChecker extends BaseChecker {
-  constructor(reporter) {
+  constructor(reporter, config) {
     super(reporter, ruleId, meta)
+
+    this.isStrict = config && config.getObjectPropertyBoolean(ruleId, 'strict', DEFAULT_STRICTNESS)
   }
 
   ContractDefinition(node) {
@@ -53,6 +78,12 @@ class PrivateVarsLeadingUnderscoreChecker extends BaseChecker {
 
   VariableDeclaration(node) {
     if (!this.inStateVariableDeclaration) {
+      // if it is trict, non-state vars should not start with leading underscore
+      if (this.isStrict) {
+        if (node.name !== null && naming.hasLeadingUnderscore(node.name)) {
+          return this.error(node, 'Non-State variable name must not start with underscore ')
+        }
+      }
       return
     }
 

--- a/test/rules/naming/private-vars-leading-underscore.js
+++ b/test/rules/naming/private-vars-leading-underscore.js
@@ -21,6 +21,13 @@ describe('Linter - private-vars-leading-underscore', () => {
     libraryWith('function _foo() public {}'),
     libraryWith('function _foo() internal {}')
   ]
+  const SHOULD_WARN_STRICT_CASES = [
+    contractWith('function foo() { uint _bar; }'),
+    contractWith('function foo(uint _bar) {}'),
+    contractWith('function foo() returns (uint256 _bar) {}'),
+    libraryWith('function foo() returns (uint256 _bar) {}'),
+    libraryWith('function foo(uint _bar) {}')
+  ]
   const SHOULD_NOT_WARN_CASES = [
     // don't warn when private/internal names start with _
     contractWith('uint _foo;'),
@@ -44,19 +51,13 @@ describe('Linter - private-vars-leading-underscore', () => {
 
     // other names (variables, parameters, returns) shouldn't be affected by this rule
     contractWith('function foo(uint bar) {}'),
-    contractWith('function foo(uint _bar) {}'),
     contractWith('function foo() { uint bar; }'),
-    contractWith('function foo() { uint _bar; }'),
     contractWith('function foo() returns (uint256) {}'),
     contractWith('function foo() returns (uint256 bar) {}'),
-    contractWith('function foo() returns (uint256 _bar) {}'),
     libraryWith('function foo(uint bar) {}'),
-    libraryWith('function foo(uint _bar) {}'),
     libraryWith('function foo() { uint bar; }'),
-    libraryWith('function foo() { uint _bar; }'),
     libraryWith('function foo() returns (uint256) {}'),
-    libraryWith('function foo() returns (uint256 bar) {}'),
-    libraryWith('function foo() returns (uint256 _bar) {}')
+    libraryWith('function foo() returns (uint256 bar) {}')
   ]
 
   SHOULD_WARN_CASES.forEach((code, index) => {
@@ -69,13 +70,33 @@ describe('Linter - private-vars-leading-underscore', () => {
     })
   })
 
-  SHOULD_NOT_WARN_CASES.forEach((code, index) => {
+  SHOULD_WARN_STRICT_CASES.concat(SHOULD_NOT_WARN_CASES).forEach((code, index) => {
     it(`should not emit a warning (${index})`, () => {
       const report = linter.processStr(code, {
         rules: { 'private-vars-leading-underscore': 'error' }
       })
 
       assert.equal(report.errorCount, 0)
+    })
+  })
+
+  SHOULD_NOT_WARN_CASES.forEach((code, index) => {
+    it(`should not emit a warning (${index})`, () => {
+      const report = linter.processStr(code, {
+        rules: { 'private-vars-leading-underscore': ['error', { strict: true }] }
+      })
+
+      assert.equal(report.errorCount, 0)
+    })
+  })
+
+  SHOULD_WARN_STRICT_CASES.forEach((code, index) => {
+    it(`should not emit a warning (${index})`, () => {
+      const report = linter.processStr(code, {
+        rules: { 'private-vars-leading-underscore': ['error', { strict: true }] }
+      })
+
+      assert.equal(report.errorCount, 1)
     })
   })
 })


### PR DESCRIPTION
Rationale:

While we have private-vars-leading-underscore, sometimes people also uses underscore for non state variable. That will actually make the private state variable leading underscore almost losing its usefulness: to tell that it is a private or internal state var when seeing an underscore.

Adding a strict mode to `private-vars-leading-underscore` rule specifically to forbid non state variable having lead underscore.