### PR TITLE
Add comprehensive-interface rule

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -19,6 +19,13 @@ title:       "Rule Index of Solhint"
 | [constructor-syntax](./rules/best-practises/constructor-syntax.md) | Constructors should use the new constructor keyword.                                                                  |             |
         
 
+## Miscellaneous
+
+| Rule Id                                                                     | Error                                                                                                                                  | Recommended |
+| --------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| [comprehensive-interface](./rules/miscellaneous/comprehensive-interface.md) | Check that all public or external functions are override. This is iseful to make sure that the whole API is extracted in an interface. |             |
+        
+
 ## Style Guide Rules
 
 | Rule Id                                                                              | Error                                                                                  | Recommended |

--- a/docs/rules/miscellaneous/comprehensive-interface.md
+++ b/docs/rules/miscellaneous/comprehensive-interface.md
@@ -1,0 +1,60 @@
+---
+warning:     "This is a dynamically generated file. Do not edit manually."
+layout:      "default"
+title:       "comprehensive-interface | Solhint"
+---
+
+# comprehensive-interface
+![Category Badge](https://img.shields.io/badge/-Miscellaneous-informational)
+![Default Severity Badge warn](https://img.shields.io/badge/Default%20Severity-warn-yellow)
+
+## Description
+Check that all public or external functions are override. This is iseful to make sure that the whole API is extracted in an interface.
+
+## Options
+This rule accepts a string option of rule severity. Must be one of "error", "warn", "off". Default to warn.
+
+### Example Config
+```json
+{
+  "rules": {
+    "comprehensive-interface": "warn"
+  }
+}
+```
+
+
+## Examples
+### 👍 Examples of **correct** code for this rule
+
+#### All public functions are overrides
+
+```solidity
+pragma solidity ^0.7.0;
+
+contract Foo is FooInterface {
+  function foo() public override {}
+}
+
+```
+
+### 👎 Examples of **incorrect** code for this rule
+
+#### A public function is not an override
+
+```solidity
+pragma solidity ^0.7.0;
+
+contract Foo {
+  function foo() public {}
+}
+
+```
+
+## Version
+This rule is introduced in the latest version.
+
+## Resources
+- [Rule source](https://github.com/protofire/solhint/tree/master/lib/rules/miscellaneous/comprehensive-interface.js)
+- [Document source](https://github.com/protofire/solhint/tree/master/docs/rules/miscellaneous/comprehensive-interface.md)
+- [Test cases](https://github.com/protofire/solhint/tree/master/test/rules/miscellaneous/comprehensive-interface.js)

--- a/lib/rules/miscellaneous/comprehensive-interface.js
+++ b/lib/rules/miscellaneous/comprehensive-interface.js
@@ -9,8 +9,18 @@ const meta = {
       'Check that all public or external functions are override. This is iseful to make sure that the whole API is extracted in an interface.',
     category: 'Miscellaneous',
     examples: {
-      good: require('../../../test/fixtures/miscellaneous/public-function-with-override'),
-      bad: require('../../../test/fixtures/miscellaneous/public-function-no-override')
+      good: [
+        {
+          description: 'All public functions are overrides',
+          code: require('../../../test/fixtures/miscellaneous/public-function-with-override')
+        }
+      ],
+      bad: [
+        {
+          description: 'A public function is not an override',
+          code: require('../../../test/fixtures/miscellaneous/public-function-no-override')
+        }
+      ]
     }
   },
 

--- a/lib/rules/miscellaneous/comprehensive-interface.js
+++ b/lib/rules/miscellaneous/comprehensive-interface.js
@@ -43,7 +43,10 @@ class ComprehensiveInterface extends BaseChecker {
     const isOverride = node.override !== null
 
     if (isPublic && !isOverride) {
-      this.error(node, 'All public or external methods in a contract must override a definition from an interface')
+      this.error(
+        node,
+        'All public or external methods in a contract must override a definition from an interface'
+      )
     }
   }
 }

--- a/lib/rules/miscellaneous/comprehensive-interface.js
+++ b/lib/rules/miscellaneous/comprehensive-interface.js
@@ -43,7 +43,7 @@ class ComprehensiveInterface extends BaseChecker {
     const isOverride = node.override !== null
 
     if (isPublic && !isOverride) {
-      this.error(node, 'All public methods have to be an override')
+      this.error(node, 'All public or external methods in a contract must override a definition from an interface')
     }
   }
 }

--- a/lib/rules/miscellaneous/comprehensive-interface.js
+++ b/lib/rules/miscellaneous/comprehensive-interface.js
@@ -1,0 +1,51 @@
+const BaseChecker = require('./../base-checker')
+
+const ruleId = 'comprehensive-interface'
+const meta = {
+  type: 'miscellaneous',
+
+  docs: {
+    description:
+      'Check that all public or external functions are override. This is iseful to make sure that the whole API is extracted in an interface.',
+    category: 'Miscellaneous',
+    examples: {
+      good: require('../../../test/fixtures/miscellaneous/public-function-with-override'),
+      bad: require('../../../test/fixtures/miscellaneous/public-function-no-override')
+    }
+  },
+
+  isDefault: false,
+  recommended: false,
+  defaultSetup: 'warn',
+
+  schema: null
+}
+
+class ComprehensiveInterface extends BaseChecker {
+  constructor(reporter) {
+    super(reporter, ruleId, meta)
+  }
+
+  ContractDefinition(node) {
+    this.isContract = node.kind === 'contract'
+  }
+
+  'ContractDefinition:exit'() {
+    this.isContract = false
+  }
+
+  FunctionDefinition(node) {
+    if (!this.isContract) {
+      return
+    }
+
+    const isPublic = node.visibility === 'public' || node.visibility === 'external'
+    const isOverride = node.override !== null
+
+    if (isPublic && !isOverride) {
+      this.error(node, 'All public methods have to be an override')
+    }
+  }
+}
+
+module.exports = ComprehensiveInterface

--- a/lib/rules/miscellaneous/index.js
+++ b/lib/rules/miscellaneous/index.js
@@ -1,5 +1,9 @@
 const QuotesChecker = require('./quotes')
+const ComprehensiveInterfaceChecker = require('./comprehensive-interface')
 
 module.exports = function checkers(reporter, config, tokens) {
-  return [new QuotesChecker(reporter, config, tokens)]
+  return [
+    new QuotesChecker(reporter, config, tokens),
+    new ComprehensiveInterfaceChecker(reporter, config, tokens)
+  ]
 }

--- a/test/fixtures/miscellaneous/public-function-no-override.js
+++ b/test/fixtures/miscellaneous/public-function-no-override.js
@@ -1,0 +1,6 @@
+module.exports = `pragma solidity ^0.7.0;
+
+contract Foo {
+  function foo() public {}
+}
+`

--- a/test/fixtures/miscellaneous/public-function-with-override.js
+++ b/test/fixtures/miscellaneous/public-function-with-override.js
@@ -1,0 +1,6 @@
+module.exports = `pragma solidity ^0.7.0;
+
+contract Foo is FooInterface {
+  function foo() public override {}
+}
+`

--- a/test/rules/miscellaneous/comprehensive-interface.js
+++ b/test/rules/miscellaneous/comprehensive-interface.js
@@ -10,7 +10,11 @@ describe('Linter - comprehensive-interface', () => {
     })
 
     assert.equal(report.errorCount, 1)
-    assert.ok(report.messages[0].message.includes('All public methods have to be an override'))
+    assert.ok(
+      report.messages[0].message.includes(
+        'All public or external methods in a contract must override a definition from an interface'
+      )
+    )
   })
 
   it('should not raise an error', () => {

--- a/test/rules/miscellaneous/comprehensive-interface.js
+++ b/test/rules/miscellaneous/comprehensive-interface.js
@@ -1,0 +1,25 @@
+const assert = require('assert')
+const linter = require('./../../../lib/index')
+
+describe('Linter - comprehensive-interface', () => {
+  it('should raise an error', () => {
+    const code = require('../../fixtures/miscellaneous/public-function-no-override')
+
+    const report = linter.processStr(code, {
+      rules: { 'comprehensive-interface': 'error' }
+    })
+
+    assert.equal(report.errorCount, 1)
+    assert.ok(report.messages[0].message.includes('All public methods have to be an override'))
+  })
+
+  it('should not raise an error', () => {
+    const code = require('../../fixtures/miscellaneous/public-function-with-override')
+
+    const report = linter.processStr(code, {
+      rules: { 'comprehensive-interface': 'error' }
+    })
+
+    assert.equal(report.errorCount, 0)
+  })
+})


### PR DESCRIPTION
Adds a `comprehensive-interface` rule that checks that all public/external functions are overrides. This is useful to make sure that the contract's interface is extracted in a... well... interface.

cc @nventuro