### PR TITLE
select files for publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,11 @@
   "bin": {
     "solhint": "solhint.js"
   },
+  "files": [
+    "/conf/",
+    "/lib/",
+    "/solhint.js"
+  ],
   "author": "Ilya Drabenia <ilya.drobenya@gmail.com>",
   "license": "MIT",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "files": [
     "/conf/",
     "/lib/",
+    "/test/",
     "/solhint.js"
   ],
   "author": "Ilya Drabenia <ilya.drobenya@gmail.com>",


### PR DESCRIPTION
remove garbage and clutter from the published pack. currently, it has a lot of files that shouldn't be published, some of them are very large. for example: `e2e/node_modules/*`.

before (https://registry.npmjs.org/solhint/-/solhint-3.3.0.tgz):
![Screen Shot 2020-10-26 at 23 08 29](https://user-images.githubusercontent.com/216636/97234127-c8aa1600-1812-11eb-80b8-35d3b38c561e.png)

after:
![Screen Shot 2020-10-26 at 23 08 46](https://user-images.githubusercontent.com/216636/97234139-cd6eca00-1812-11eb-948d-a1f717c900eb.png)
