### PR TITLE
Avoid counting `immutable` for the `max-state-count` rule

### DIFF
--- a/lib/rules/best-practises/max-states-count.js
+++ b/lib/rules/best-practises/max-states-count.js
@@ -55,7 +55,9 @@ class MaxStatesCountChecker extends BaseChecker {
   ContractDefinition(node) {
     const countOfVars = _(node.subNodes)
       .filter(({ type }) => type === 'StateVariableDeclaration')
-      .flatMap(subNode => subNode.variables.filter(variable => !variable.isDeclaredConst))
+      .flatMap(({ variables }) =>
+        variables.filter(({ isDeclaredConst, isImmutable }) => !isDeclaredConst && !isImmutable)
+      )
       .value().length
 
     if (countOfVars > this.maxStatesCount) {

--- a/test/rules/best-practises/max-states-count.js
+++ b/test/rules/best-practises/max-states-count.js
@@ -45,4 +45,18 @@ describe('Linter - max-states-count', () => {
 
     assertNoErrors(report)
   })
+
+  it('should not count immutable variables', () => {
+    const code = contractWith(`
+      uint public immutable a;
+      uint public b;
+      uint public c;
+
+      function f() {}
+    `)
+
+    const report = linter.processStr(code, { rules: { 'max-states-count': ['error', 2] } })
+
+    assertNoErrors(report)
+  })
 })


### PR DESCRIPTION
closes #258