### PR TITLE
(Fix) "ordering" rule

### DIFF
--- a/docs/rules/order/ordering.md
+++ b/docs/rules/order/ordering.md
@@ -30,57 +30,76 @@ This rule accepts a string option of rule severity. Must be one of "error", "war
 #### All units are in order
 
 ```solidity
-
 pragma solidity ^0.6.0;
 
 import "./some/library.sol";
 import "./some/other-library.sol";
 
-enum MyEnum {
-  Foo,
-  Bar
-}
+    enum MyEnum {
+        Foo,
+        Bar
+    }
 
-struct MyStruct {
-  uint x;
-  uint y;
-}
+    struct MyStruct {
+        uint x;
+        uint y;
+    }
 
 interface IBox {
-  function getValue() public;
-  function setValue(uint) public;
+    function getValue() public;
+    function setValue(uint) public;
 }
 
 library MyLibrary {
-  function add(uint a, uint b, uint c) public returns (uint) {
-    return a + b + c;
-  }
+    function add(uint a, uint b, uint c) public returns (uint) {
+        return a + b + c;
+    }
 }
 
 contract MyContract {
-  struct InnerStruct {
-    bool flag;
-  }
+    using MyLibrary for uint;
 
-  enum InnerEnum {
-    A, B, C
-  }
+    struct InnerStruct {
+        bool flag;
+    }
 
-  uint public x;
-  uint public y;
+    enum InnerEnum {
+        A, B, C
+    }
 
-  event MyEvent(address a);
+    address payable owner;
+    uint public x;
+    uint public y;
 
-  constructor () public {}
+    event MyEvent(address a);
 
-  fallback () external {}
+    modifier onlyOwner {
+        require(
+            msg.sender == owner,
+            "Only owner can call this function."
+        );
+        _;
+    }
 
-  function myExternalFunction() external {}
-  function myExternalConstFunction() external const {}
-  function myPublicFunction() public {}
-  function myPublicConstFunction() public const {}
-  function myInternalFunction() internal {}
-  function myPrivateFunction() private {}
+    constructor () public {}
+
+    fallback () external {}
+
+    function myExternalFunction() external {}
+    function myExternalViewFunction() external view {}
+    function myExternalPureFunction() external pure {}
+
+    function myPublicFunction() public {}
+    function myPublicViewFunction() public view {}
+    function myPublicPureFunction() public pure {}
+
+    function myInternalFunction() internal {}
+    function myInternalViewFunction() internal view {}
+    function myInternalPureFunction() internal pure {}
+
+    function myPrivateFunction() private {}
+    function myPrivateViewFunction() private view {}
+    function myPrivatePureFunction() private pure {}
 }
 
 ```

--- a/lib/rules/order/ordering.js
+++ b/lib/rules/order/ordering.js
@@ -67,8 +67,16 @@ class OrderingChecker extends BaseChecker {
   }
 }
 
-function isConst(node) {
-  return ['pure', 'view', 'constant'].includes(node.stateMutability)
+function getMutabilityWeight({ baseWeight, stateMutability }) {
+  switch (stateMutability) {
+    case 'constant':
+    case 'view':
+      return baseWeight + 2
+    case 'pure':
+      return baseWeight + 4
+    default:
+      return baseWeight
+  }
 }
 
 function isTypeDeclaration(node) {
@@ -106,6 +114,10 @@ function sourceUnitPartOrder(node) {
 }
 
 function contractPartOrder(node) {
+  if (node.type === 'UsingForDeclaration') {
+    return [0, 'using for declaration']
+  }
+
   if (isTypeDeclaration(node)) {
     let label
     if (node.type === 'StructDefinition') {
@@ -113,47 +125,59 @@ function contractPartOrder(node) {
     } else {
       label = 'enum definition'
     }
-    return [0, label]
+
+    return [10, label]
   }
 
   if (node.type === 'StateVariableDeclaration') {
-    return [10, 'state variable declaration']
+    return [20, 'state variable declaration']
   }
 
   if (node.type === 'EventDefinition') {
-    return [20, 'event definition']
+    return [30, 'event definition']
+  }
+
+  if (node.type === 'ModifierDefinition') {
+    return [40, 'modifier definition']
   }
 
   if (node.isConstructor) {
-    return [30, 'constructor']
+    return [50, 'constructor']
   }
 
   if (isReceiveFunction(node)) {
-    return [40, 'receive function']
+    return [60, 'receive function']
   }
 
   if (isFallbackFunction(node)) {
-    return [50, 'fallback function']
+    return [70, 'fallback function']
   }
 
   if (node.type === 'FunctionDefinition') {
-    if (node.visibility === 'external' && !isConst(node)) {
-      return [60, 'external function']
+    const { stateMutability, visibility } = node
+
+    if (visibility === 'external') {
+      const weight = getMutabilityWeight({ baseWeight: 80, stateMutability })
+      const label = [visibility, stateMutability, 'function'].join(' ')
+
+      return [weight, label]
     }
-    if (node.visibility === 'external' && isConst(node)) {
-      return [70, 'external const function']
+
+    if (visibility === 'public') {
+      const weight = getMutabilityWeight({ baseWeight: 90, stateMutability })
+      const label = [visibility, stateMutability, 'function'].join(' ')
+
+      return [weight, label]
     }
-    if (node.visibility === 'public' && !isConst(node)) {
-      return [80, 'public function']
+    if (visibility === 'internal') {
+      const weight = getMutabilityWeight({ baseWeight: 100, stateMutability })
+      const label = [visibility, stateMutability, 'function'].join(' ')
+      return [weight, label]
     }
-    if (node.visibility === 'public' && isConst(node)) {
-      return [90, 'public const function']
-    }
-    if (node.visibility === 'internal') {
-      return [100, 'internal function']
-    }
-    if (node.visibility === 'private') {
-      return [110, 'private function']
+    if (visibility === 'private') {
+      const weight = getMutabilityWeight({ baseWeight: 110, stateMutability })
+      const label = [visibility, stateMutability, 'function'].join(' ')
+      return [weight, label]
     }
     throw new Error('Unknown order for function, please report this issue')
   }

--- a/lib/rules/order/ordering.js
+++ b/lib/rules/order/ordering.js
@@ -169,16 +169,19 @@ function contractPartOrder(node) {
 
       return [weight, label]
     }
+
     if (visibility === 'internal') {
       const weight = getMutabilityWeight({ baseWeight: 100, stateMutability })
       const label = [visibility, stateMutability, 'function'].join(' ')
       return [weight, label]
     }
+
     if (visibility === 'private') {
       const weight = getMutabilityWeight({ baseWeight: 110, stateMutability })
       const label = [visibility, stateMutability, 'function'].join(' ')
       return [weight, label]
     }
+
     throw new Error('Unknown order for function, please report this issue')
   }
 

--- a/test/fixtures/order/ordering-correct.js
+++ b/test/fixtures/order/ordering-correct.js
@@ -1,8 +1,8 @@
 module.exports = [
   {
-    description: 'All units are in order',
+    description: 'All units are in order - ^0.4.0',
     code: `
-pragma solidity ^0.6.0;
+pragma solidity ^0.4.0;
 
 import "./some/library.sol";
 import "./some/other-library.sol";
@@ -47,11 +47,89 @@ contract MyContract {
   fallback () external {}
 
   function myExternalFunction() external {}
-  function myExternalConstFunction() external const {}
+  function myExternalConstantFunction() external constant {}
+
   function myPublicFunction() public {}
-  function myPublicConstFunction() public const {}
+  function myPublicConstantFunction() public constant {}
+
   function myInternalFunction() internal {}
   function myPrivateFunction() private {}
+}
+`
+  },
+  {
+    description: 'All units are in order - ^0.5.0',
+    code: `
+pragma solidity ^0.5.0;
+
+import "./some/library.sol";
+import "./some/other-library.sol";
+
+enum MyEnum {
+  Foo,
+  Bar
+}
+
+struct MyStruct {
+  uint x;
+  uint y;
+}
+
+interface IBox {
+  function getValue() public;
+  function setValue(uint) public;
+}
+
+library MyLibrary {
+  function add(uint a, uint b, uint c) public returns (uint) {
+    return a + b + c;
+  }
+}
+
+contract MyContract {
+  using MyLibrary for uint;
+
+  struct InnerStruct {
+    bool flag;
+  }
+
+  enum InnerEnum {
+    A, B, C
+  }
+
+  address payable owner;
+  uint public x;
+  uint public y;
+
+  event MyEvent(address a);
+
+  modifier onlyOwner {
+    require(
+      msg.sender == owner,
+      "Only owner can call this function."
+    );
+    _;
+  }
+
+  constructor () public {}
+
+  fallback () external {}
+
+  function myExternalFunction() external {}
+  function myExternalViewFunction() external view {}
+  function myExternalPureFunction() external pure {}
+
+  function myPublicFunction() public {}
+  function myPublicViewFunction() public view {}
+  function myPublicPureFunction() public pure {}
+
+  function myInternalFunction() internal {}
+  function myInternalViewFunction() internal view {}
+  function myInternalPureFunction() internal pure {}
+
+  function myPrivateFunction() private {}
+  function myPrivateViewFunction() private view {}
+  function myPrivatePureFunction() private pure {}
 }
 `
   }

--- a/test/fixtures/order/ordering-correct.js
+++ b/test/fixtures/order/ordering-correct.js
@@ -132,5 +132,83 @@ contract MyContract {
   function myPrivatePureFunction() private pure {}
 }
 `
+  },
+  {
+    description: 'All units are in order - ^0.6.0',
+    code: `
+pragma solidity ^0.6.0;
+
+import "./some/library.sol";
+import "./some/other-library.sol";
+
+enum MyEnum {
+  Foo,
+  Bar
+}
+
+struct MyStruct {
+  uint x;
+  uint y;
+}
+
+interface IBox {
+  function getValue() public;
+  function setValue(uint) public;
+}
+
+library MyLibrary {
+  function add(uint a, uint b, uint c) public returns (uint) {
+    return a + b + c;
+  }
+}
+
+contract MyContract {
+  using MyLibrary for uint;
+
+  struct InnerStruct {
+    bool flag;
+  }
+
+  enum InnerEnum {
+    A, B, C
+  }
+
+  address payable owner;
+  uint public x;
+  uint public y;
+
+  event MyEvent(address a);
+
+  modifier onlyOwner {
+    require(
+      msg.sender == owner,
+      "Only owner can call this function."
+    );
+    _;
+  }
+
+  constructor () public {}
+
+  receive() external payable {}
+
+  fallback () external {}
+
+  function myExternalFunction() external {}
+  function myExternalViewFunction() external view {}
+  function myExternalPureFunction() external pure {}
+
+  function myPublicFunction() public {}
+  function myPublicViewFunction() public view {}
+  function myPublicPureFunction() public pure {}
+
+  function myInternalFunction() internal {}
+  function myInternalViewFunction() internal view {}
+  function myInternalPureFunction() internal pure {}
+
+  function myPrivateFunction() private {}
+  function myPrivateViewFunction() private view {}
+  function myPrivatePureFunction() private pure {}
+}
+`
   }
 ]

--- a/test/fixtures/order/ordering-incorrect.js
+++ b/test/fixtures/order/ordering-incorrect.js
@@ -24,5 +24,55 @@ module.exports = [
 
   interface MyInterface {}
 `
+  },
+  {
+    description: 'Use for after state variable',
+    code: `
+contract MyContract {
+  uint public x;
+  
+  using MyMathLib for uint;
+}
+`
+  },
+  {
+    description: 'External pure before external view',
+    code: `
+contract MyContract {
+  function myExternalFunction() external {}
+  function myExternalPureFunction() external pure {}
+  function myExternalViewFunction() external view {}
+}
+`
+  },
+  {
+    description: 'Public pure before public view',
+    code: `
+contract MyContract {
+  function myPublicFunction() public {}
+  function myPublicPureFunction() public pure {}
+  function myPublicViewFunction() public view {}
+}
+`
+  },
+  {
+    description: 'Internal pure before internal view',
+    code: `
+contract MyContract {
+  function myInternalFunction() internal {}
+  function myInternalPureFunction() internal pure {}
+  function myInternalViewFunction() internal view {}
+}
+`
+  },
+  {
+    description: 'Private pure before private view',
+    code: `
+contract MyContract {
+  function myPrivateFunction() private {}
+  function myPrivatePureFunction() private pure {}
+  function myPrivateViewFunction() private view {}
+}
+`
   }
 ]


### PR DESCRIPTION
This PR closes #274, by:

- fixing `constant` modifier (it was expecting it as `const`, which lead the linter to interpret those functions as lacking state mutability)
- adding missing contract parts: `modifier` and `using for`
- enforce granularity in the functions mutability order (see https://github.com/protofire/solhint/issues/274#issuecomment-744566371)

By adding the missing contract parts, this is the definitive order which I defined for the contract body:

1. `using for`
2. `struct/enum`
3. state variable declaration
4. `event`
5. `modifier`
6. `constructor`
7. `receive`
8. `fallback`
9. `external`
10. `external view` (or `external const` for version previous to 0.5.0)
11. `external pure`
12. `public`
13. `public view` (or `public const` for version previous to 0.5.0)
14. `public pure`
15. `internal`
16. `internal view` (or `internal const` for version previous to 0.5.0)
17. `internal pure`
18. `private`
19. `private view` (or `private const` for version previous to 0.5.0)
20. `private pure`