### PR TITLE
Fix `func-name-mixedcase` docs description to say mixedCase

### DIFF
--- a/lib/rules/naming/func-name-mixedcase.js
+++ b/lib/rules/naming/func-name-mixedcase.js
@@ -6,7 +6,7 @@ const meta = {
   type: 'naming',
 
   docs: {
-    description: 'Function name must be in camelCase.',
+    description: 'Function name must be in mixedCase.',
     category: 'Style Guide Rules'
   },
 


### PR DESCRIPTION
Fix typo in the docs section of the `func-name-mixedcase` rule that was being propagated throughout the rest of the docs.