### PR TITLE
make --quiet option work for all files

### DIFF
--- a/solhint.js
+++ b/solhint.js
@@ -90,7 +90,9 @@ function execMainAction() {
 
   if (program.quiet) {
     // filter the list of reports, to set errors only.
-    reports[0].reports = reports[0].reports.filter(i => i.severity === 2)
+    reports.forEach(reporter => {
+      reporter.reports = reporter.reports.filter(i => i.severity === 2)
+    });
   }
 
   if (printReports(reports, formatterFn)) {


### PR DESCRIPTION
Currently, the `--quiet` option only applies to the first file evaluated by solhint.

Say you have a directory with three contracts: `contracts/Greeter.sol`, `contracts/Greeter2.sol` and `contracts/Greeter3.sol`. All three contracts have one error and one warning.

If you run `solhint contract/**/*.sol`, you'll see all errors and warnings:

<img width="789" alt="Screen Shot 2021-12-28 at 5 18 45 PM" src="https://user-images.githubusercontent.com/2570291/147618790-7d976ae7-fcf9-4ce5-ae32-89279da36cbd.png">

But if you run `solhint --quiet contract/**/*.sol`, you'll see all errors for the first file (Greeter.sol) and errors+warnings for the other two files:

<img width="805" alt="Screen Shot 2021-12-28 at 5 19 00 PM" src="https://user-images.githubusercontent.com/2570291/147618827-adf74e18-3500-4a57-9350-7f29458e2359.png">

Presumably, the preferred behavior is to hide warnings for all files:

<img width="855" alt="Screen Shot 2021-12-28 at 5 19 48 PM" src="https://user-images.githubusercontent.com/2570291/147618845-87d8002b-bd24-4f07-81af-6adb5cb54254.png">

This patch hides warnings for all files when the `--quiet` flag is passed.