### PR TITLE
Allow low level method calls for transferring funds

### DIFF
--- a/lib/rules/security/avoid-low-level-calls.js
+++ b/lib/rules/security/avoid-low-level-calls.js
@@ -9,6 +9,12 @@ const meta = {
     description: `Avoid to use low level calls.`,
     category: 'Security Rules',
     examples: {
+      good: [
+        {
+          description: 'Using low level calls to transfer funds',
+          code: require('../../../test/fixtures/security/allowed-low-level-calls').join('\n')
+        }
+      ],
       bad: [
         {
           description: 'Using low level calls',
@@ -30,9 +36,29 @@ class AvoidLowLevelCallsChecker extends BaseChecker {
     super(reporter, ruleId, meta)
   }
 
-  MemberAccess(node) {
-    if (hasMethodCalls(node, ['call', 'callcode', 'delegatecall'])) {
-      this._warn(node)
+  FunctionCall(node) {
+    switch (node.expression.type) {
+      case 'MemberAccess':
+        if (hasMethodCalls(node.expression, ['call', 'callcode', 'delegatecall'])) {
+          return this._warn(node)
+        }
+      case 'NameValueExpression':
+        // Allow low level method calls for transferring funds
+        //
+        // See:
+        //
+        // - https://solidity-by-example.org/sending-ether/
+        // - https://consensys.net/diligence/blog/2019/09/stop-using-soliditys-transfer-now/
+        if (node.expression.expression.memberName === 'call'
+          && node.expression.arguments.type === 'NameValueList'
+          && node.expression.arguments.names.includes('value')
+        ) {
+          return
+        }
+
+        if (hasMethodCalls(node.expression.expression, ['call', 'callcode', 'delegatecall'])) {
+          return this._warn(node)
+        }
     }
   }
 

--- a/test/fixtures/security/allowed-low-level-calls.js
+++ b/test/fixtures/security/allowed-low-level-calls.js
@@ -1,0 +1,1 @@
+module.exports = ['msg.sender.call{value: 1 ether}("");']

--- a/test/rules/security/avoid-low-level-calls.js
+++ b/test/rules/security/avoid-low-level-calls.js
@@ -4,15 +4,26 @@ const { assertWarnsCount, assertErrorMessage } = require('./../../common/asserts
 
 describe('Linter - avoid-low-level-calls', () => {
   const LOW_LEVEL_CALLS = require('../../fixtures/security/low-level-calls').map(funcWith)
+  const ALLOWED_LOW_LEVEL_CALLS = require('../../fixtures/security/allowed-low-level-calls').map(funcWith)
 
   LOW_LEVEL_CALLS.forEach(curCode =>
-    it('should return warn when code contains possible reentrancy', () => {
+    it('should return warn when code contains low level calls', () => {
       const report = linter.processStr(curCode, {
         rules: { 'avoid-low-level-calls': 'warn' }
       })
 
       assertWarnsCount(report, 1)
       assertErrorMessage(report, 'low level')
+    })
+  )
+
+  ALLOWED_LOW_LEVEL_CALLS.forEach(curCode =>
+    it('should not return warn when code contains low level calls', () => {
+      const report = linter.processStr(curCode, {
+        rules: { 'avoid-low-level-calls': 'warn' }
+      })
+
+      assertWarnsCount(report, 0)
     })
   )
 })


### PR DESCRIPTION
See:

- https://solidity-by-example.org/sending-ether/
- https://consensys.net/diligence/blog/2019/09/stop-using-soliditys-transfer-now/

Closes #307