### PR TITLE
allow more flexible fixer utilizing current src

### DIFF
--- a/solhint.js
+++ b/solhint.js
@@ -76,7 +76,7 @@ function execMainAction() {
 
       const fixes = _(report.reports)
         .filter(x => x.fix)
-        .map(x => x.fix(ruleFixer))
+        .map(x => x.fix(ruleFixer, inputSrc))
         .sort((a, b) => a.range[0] - b.range[0])
         .value()
 


### PR DESCRIPTION
I'm trying to create a fixer for ordering rule, but cannot do that without referencing the current source.