### PR TITLE
Upgrade @solidity-parser/parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "author": "Ilya Drabenia <ilya.drobenya@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@solidity-parser/parser": "^0.13.2",
+    "@solidity-parser/parser": "^0.14.1",
     "ajv": "^6.6.1",
     "antlr4": "4.7.1",
     "ast-parents": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "author": "Ilya Drabenia <ilya.drobenya@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@solidity-parser/parser": "^0.14.1",
+    "@solidity-parser/parser": "^0.14.2",
     "ajv": "^6.6.1",
     "antlr4": "4.7.1",
     "ast-parents": "0.0.1",


### PR DESCRIPTION
This will add support for memory-safe assembly inline blocks:

```diff
-        assembly {
+        assembly ("memory-safe") {
```

as per https://docs.soliditylang.org/en/v0.8.13/assembly.html#memory-safety

Currently parsing errors due to the outdated version:

```
  195:17  error  Parse error: extraneous input '(' expecting {'{', StringLiteralFragment}
  195:31  error  Parse error: extraneous input ')' expecting '{'
```

The upgrade was successfully tested in the https://github.com/patrickd-/cheatsheet.sol repository