### PR TITLE
fix: bug directories with .sol in the name treated as files

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -61,7 +61,7 @@ function processFile(file, config) {
 function processPath(path, config) {
   const ignoreFilter = ignore().add(config.excludedFiles)
 
-  const allFiles = glob.sync(path, {})
+  const allFiles = glob.sync(path, {}).filter(f => fs.lstatSync(f).isFile())
   const files = ignoreFilter.filter(allFiles)
 
   return files.map(curFile => processFile(curFile, config))


### PR DESCRIPTION
Without this patch, the path, for example,
artifacts/@openzeppelin/contracts/token/ERC20/ERC20.sol/ERC20.dbg.js
will be treated as a file
artifacts/@openzeppelin/contracts/token/ERC20/ERC20.sol
on MacOS system. As a result, npm module fs throws the error:
'Error: EISDIR: illegal operation on a directory'

This patch solves the problem by checking if the path is a file and not
a directory.