### PR TITLE
Fix of ordering rule for CustomErrorDefinition

### DIFF
--- a/lib/rules/order/ordering.js
+++ b/lib/rules/order/ordering.js
@@ -137,6 +137,10 @@ function contractPartOrder(node) {
     return [30, 'event definition']
   }
 
+  if (node.type === 'CustomErrorDefinition') {
+    return [35, 'custom error definition']
+  }
+
   if (node.type === 'ModifierDefinition') {
     return [40, 'modifier definition']
   }


### PR DESCRIPTION
Currently when smart contract contains Custom errors such as:

error MyError();

Ordering rule fails since it throws "Unrecognized contract part, please report this issue".
