### PR TITLE
Linter fixes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,13 +1,13 @@
 module.exports = {
   parserOptions: {
-    ecmaVersion: 8
+    ecmaVersion: 8,
   },
   env: {
     browser: false,
     node: true,
     commonjs: true,
     es6: true,
-    mocha: true
+    mocha: true,
   },
   extends: ['airbnb-base', 'plugin:prettier/recommended'],
   rules: {
@@ -32,6 +32,6 @@ module.exports = {
     'class-methods-use-this': 'off',
     'guard-for-in': 'off',
     'no-shadow': 'off',
-    'no-underscore-dangle': 'off'
-  }
+    'no-underscore-dangle': 'off',
+  },
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,6 +13,7 @@ module.exports = {
   rules: {
     'consistent-return': 'off',
     'import/no-dynamic-require': 'off',
+    'max-classes-per-file': 'off',
     'import/no-extraneous-dependencies': ['error', { optionalDependencies: true }],
     'global-require': 'off',
     'no-bitwise': 'off',

--- a/.github/workflows/E2E.yml
+++ b/.github/workflows/E2E.yml
@@ -22,6 +22,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: pack
         run: npm pack
+      - name: lint
+        run: npm install && npm run lint
       - name: install-globally
         run: npm i -g solhint*tgz
       - name: run-e2e-tests

--- a/conf/rulesets/solhint-all.js
+++ b/conf/rulesets/solhint-all.js
@@ -3,7 +3,7 @@ const { loadRules } = require('../../lib/load-rules')
 const rulesConstants = loadRules()
 const enabledRules = {}
 
-rulesConstants.forEach(rule => {
+rulesConstants.forEach((rule) => {
   if (!rule.meta.deprecated) {
     enabledRules[rule.ruleId] = rule.meta.defaultSetup
   }

--- a/conf/rulesets/solhint-default.js
+++ b/conf/rulesets/solhint-default.js
@@ -3,7 +3,7 @@ const { loadRules } = require('../../lib/load-rules')
 const rulesConstants = loadRules()
 const enabledRules = {}
 
-rulesConstants.forEach(rule => {
+rulesConstants.forEach((rule) => {
   if (!rule.meta.deprecated && rule.meta.isDefault) {
     enabledRules[rule.ruleId] = rule.meta.defaultSetup
   }

--- a/conf/rulesets/solhint-recommended.js
+++ b/conf/rulesets/solhint-recommended.js
@@ -3,7 +3,7 @@ const { loadRules } = require('../../lib/load-rules')
 const rulesConstants = loadRules()
 const enabledRules = {}
 
-rulesConstants.forEach(rule => {
+rulesConstants.forEach((rule) => {
   if (!rule.meta.deprecated && rule.meta.recommended) {
     enabledRules[rule.ruleId] = rule.meta.defaultSetup
   }

--- a/lib/apply-fixes.js
+++ b/lib/apply-fixes.js
@@ -1,7 +1,7 @@
 function applyFixes(fixes, inputSrc) {
   if (fixes.length === 0) {
     return {
-      fixed: false
+      fixed: false,
     }
   }
 
@@ -24,7 +24,7 @@ function applyFixes(fixes, inputSrc) {
 
   return {
     fixed: true,
-    output
+    output,
   }
 }
 

--- a/lib/comment-directive-parser.js
+++ b/lib/comment-directive-parser.js
@@ -9,9 +9,9 @@ class CommentDirectiveParser {
 
   parseComments(tokens) {
     const items = tokens.filter(
-      token => token.type === 'Keyword' && /^(\/\/|\/\*)/.test(token.value)
+      (token) => token.type === 'Keyword' && /^(\/\/|\/\*)/.test(token.value)
     )
-    items.forEach(item => this.onComment(item))
+    items.forEach((item) => this.onComment(item))
   }
 
   onComment(lexema) {
@@ -61,16 +61,12 @@ class CommentDirectiveParser {
   }
 
   parseRuleIds(text, start) {
-    const ruleIds = text
-      .replace('//', '')
-      .replace('/*', '')
-      .replace('*/', '')
-      .replace(start, '')
+    const ruleIds = text.replace('//', '').replace('/*', '').replace('*/', '').replace(start, '')
 
     const rules = ruleIds
       .split(',')
-      .map(curRule => curRule.trim())
-      .filter(i => i.length > 0)
+      .map((curRule) => curRule.trim())
+      .filter((i) => i.length > 0)
 
     return rules.length > 0 ? rules : 'all'
   }
@@ -106,7 +102,7 @@ class RuleStore {
   }
 
   disableRulesToEndOfFile(startLine, rules) {
-    this._toEndOfFile(startLine, i => this.disableRules(i, rules))
+    this._toEndOfFile(startLine, (i) => this.disableRules(i, rules))
   }
 
   enableRules(curLine, rules) {
@@ -114,12 +110,12 @@ class RuleStore {
       this.disableAllByLine[curLine] = false
     } else {
       const lineRules = this.disableRuleByLine[curLine]
-      rules.forEach(curRule => lineRules.delete(curRule))
+      rules.forEach((curRule) => lineRules.delete(curRule))
     }
   }
 
   enableRulesToEndOfFile(startLine, rules) {
-    this._toEndOfFile(startLine, i => this.enableRules(i, rules))
+    this._toEndOfFile(startLine, (i) => this.enableRules(i, rules))
   }
 
   isRuleEnabled(line, ruleId) {

--- a/lib/common/ajv.js
+++ b/lib/common/ajv.js
@@ -6,7 +6,7 @@ const ajv = new Ajv({
   validateSchema: false,
   missingRefs: 'ignore',
   verbose: true,
-  schemaId: 'auto'
+  schemaId: 'auto',
 })
 
 ajv.addMetaSchema(metaSchema)

--- a/lib/common/ast-types.js
+++ b/lib/common/ast-types.js
@@ -23,5 +23,5 @@ module.exports = {
   isReceiveFunction,
   isFunctionDefinition,
   isStructDefinition,
-  isEnumDefinition
+  isEnumDefinition,
 }

--- a/lib/common/blank-line-counter.js
+++ b/lib/common/blank-line-counter.js
@@ -23,7 +23,7 @@ class BlankLineCounter {
 
   calcTokenLines(ctx) {
     if (this.tokenLines.size === 0) {
-      ctx.parser._input.tokens.forEach(i => this.addTokenLinesToMap(i))
+      ctx.parser._input.tokens.forEach((i) => this.addTokenLinesToMap(i))
     }
   }
 

--- a/lib/common/errors.js
+++ b/lib/common/errors.js
@@ -7,5 +7,5 @@ class ConfigMissingError extends Error {
 }
 
 module.exports = {
-  ConfigMissingError
+  ConfigMissingError,
 }

--- a/lib/common/identifier-naming.js
+++ b/lib/common/identifier-naming.js
@@ -29,5 +29,5 @@ module.exports = {
 
   hasLeadingUnderscore(text) {
     return text && text[0] === '_'
-  }
+  },
 }

--- a/lib/common/statements-indent-validator.js
+++ b/lib/common/statements-indent-validator.js
@@ -99,7 +99,7 @@ class SyntacticSequence {
 
   syntaxMatch(ctx) {
     const childs = ctx.children
-    const syntaxMatchers = this.items.filter(i => i.syntaxMatch)
+    const syntaxMatchers = this.items.filter((i) => i.syntaxMatch)
 
     if (!childs || childs.length === 0 || syntaxMatchers.length !== childs.length) {
       return false
@@ -115,7 +115,7 @@ class SyntacticSequence {
   }
 
   validate(callback) {
-    return this.items.filter(i => i.listenError).forEach(i => i.listenError(callback))
+    return this.items.filter((i) => i.listenError).forEach((i) => i.listenError(callback))
   }
 
   get lastItem() {

--- a/lib/common/tokens.js
+++ b/lib/common/tokens.js
@@ -117,7 +117,7 @@ class Token {
   }
 }
 
-const AlignValidatable = type =>
+const AlignValidatable = (type) =>
   class extends type {
     isIncorrectAligned() {
       return !this.isCorrectAligned()
@@ -143,5 +143,5 @@ module.exports = {
   prevTokenFromToken,
   BaseTokenList,
   Token,
-  AlignValidatable
+  AlignValidatable,
 }

--- a/lib/common/tree-traversing.js
+++ b/lib/common/tree-traversing.js
@@ -37,7 +37,7 @@ class TreeTraversing {
 
   findTypeInChildren(ctx, type) {
     if (ctx.children) {
-      const items = ctx.children.filter(i => i.constructor.name === type)
+      const items = ctx.children.filter((i) => i.constructor.name === type)
 
       return (items.length > 0 && items[0]) || null
     } else {

--- a/lib/common/utils.js
+++ b/lib/common/utils.js
@@ -19,7 +19,7 @@ const getLocFromIndex = (text, index) => {
 }
 
 const walkSync = (dir, filelist = []) => {
-  fs.readdirSync(dir).forEach(file => {
+  fs.readdirSync(dir).forEach((file) => {
     filelist = fs.statSync(path.join(dir, file)).isDirectory()
       ? walkSync(path.join(dir, file), filelist)
       : filelist.concat(path.join(dir, file))
@@ -29,5 +29,5 @@ const walkSync = (dir, filelist = []) => {
 
 module.exports = {
   getLocFromIndex,
-  walkSync
+  walkSync,
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -34,5 +34,5 @@ module.exports = {
 
   getString(ruleName, defaultValue) {
     return this.getStringByPath(`rules["${ruleName}"][1]`, defaultValue)
-  }
+  },
 }

--- a/lib/config/config-file.js
+++ b/lib/config/config-file.js
@@ -5,7 +5,7 @@ const { cosmiconfigSync } = require('cosmiconfig')
 const { ConfigMissingError } = require('../common/errors')
 const packageJson = require('../../package.json')
 
-const getSolhintCoreConfigPath = name => {
+const getSolhintCoreConfigPath = (name) => {
   if (name === 'solhint:recommended') {
     return path.resolve(__dirname, '../../conf/rulesets/solhint-recommended.js')
   }
@@ -27,10 +27,10 @@ const createEmptyConfig = () => ({
   globals: {},
   env: {},
   rules: {},
-  parserOptions: {}
+  parserOptions: {},
 })
 
-const loadConfig = configFile => {
+const loadConfig = (configFile) => {
   if (configFile && !fs.existsSync(configFile)) {
     throw new Error(`The config file passed as a parameter does not exist`)
   }
@@ -47,8 +47,8 @@ const loadConfig = configFile => {
       `.${moduleName}rc.yaml`,
       `.${moduleName}rc.yml`,
       `.${moduleName}rc.js`,
-      `${moduleName}.config.js`
-    ]
+      `${moduleName}.config.js`,
+    ],
   }
 
   const explorer = cosmiconfigSync(moduleName, cosmiconfigOptions)
@@ -65,7 +65,7 @@ const loadConfig = configFile => {
   return searchedFor.config || createEmptyConfig()
 }
 
-const configGetter = path => {
+const configGetter = (path) => {
   let extensionPath = null
 
   if (path.startsWith('solhint:')) {
@@ -102,5 +102,5 @@ const applyExtends = (config, getter = configGetter) => {
 module.exports = {
   applyExtends,
   configGetter,
-  loadConfig
+  loadConfig,
 }

--- a/lib/config/config-schema.js
+++ b/lib/config/config-schema.js
@@ -5,13 +5,13 @@ const baseConfigProperties = {
   globals: { type: 'object' },
   env: { type: 'object' },
   parserOptions: { type: 'object' },
-  plugins: { type: 'array' }
+  plugins: { type: 'array' },
 }
 
 const configSchema = {
   type: 'object',
   properties: baseConfigProperties,
-  additionalProperties: false
+  additionalProperties: false,
 }
 
 module.exports = configSchema

--- a/lib/config/config-validator.js
+++ b/lib/config/config-validator.js
@@ -10,12 +10,12 @@ const validSeverityMap = ['error', 'warn']
 const invalidSeverityMap = ['off']
 
 const defaultSchemaValueForRules = Object.freeze({
-  oneOf: [{ type: 'string', enum: [...validSeverityMap, ...invalidSeverityMap] }, { const: false }]
+  oneOf: [{ type: 'string', enum: [...validSeverityMap, ...invalidSeverityMap] }, { const: false }],
 })
 
-const formatErrors = errors =>
+const formatErrors = (errors) =>
   errors
-    .map(error => {
+    .map((error) => {
       if (error.keyword === 'additionalProperties') {
         const formattedPropertyPath = error.dataPath.length
           ? `${error.dataPath.slice(1)}.${error.params.additionalProperty}`
@@ -37,7 +37,7 @@ const formatErrors = errors =>
 
       return `"${field}" ${error.message}. Value: ${JSON.stringify(error.data)}`
     })
-    .map(message => `\t- ${message}.\n`)
+    .map((message) => `\t- ${message}.\n`)
     .join('')
 
 const deprecatedDisableValue = _.once(() => {
@@ -48,7 +48,7 @@ const deprecatedDisableValue = _.once(() => {
   )
 })
 
-const validate = config => {
+const validate = (config) => {
   validateSchema = validateSchema || ajv.compile(configSchema)
 
   if (!validateSchema(config)) {
@@ -56,7 +56,7 @@ const validate = config => {
   }
 
   // show deprecated warning for rules that are configured with `false` or `0`
-  Object.keys(config.rules || {}).forEach(key => {
+  Object.keys(config.rules || {}).forEach((key) => {
     let severity = config.rules[key]
     if (Array.isArray(severity)) {
       severity = severity[0]
@@ -72,5 +72,5 @@ module.exports = {
   validate,
   validSeverityMap,
   invalidSeverityMap,
-  defaultSchemaValueForRules
+  defaultSchemaValueForRules,
 }

--- a/lib/doc/utils.js
+++ b/lib/doc/utils.js
@@ -1,10 +1,10 @@
 const { validSeverityMap, invalidSeverityMap } = require('../config/config-validator')
 
-const formatEnum = options => options.map(op => JSON.stringify(op)).join(', ')
+const formatEnum = (options) => options.map((op) => JSON.stringify(op)).join(', ')
 const ruleSeverityEnum = formatEnum([...validSeverityMap, ...invalidSeverityMap])
 
 module.exports = {
   ruleSeverityEnum,
   severityDescription: `Rule severity. Must be one of ${ruleSeverityEnum}.`,
-  formatEnum
+  formatEnum,
 }

--- a/lib/formatters/stylish.js
+++ b/lib/formatters/stylish.js
@@ -2,11 +2,10 @@
  * @fileoverview Stylish reporter
  * @author Sindre Sorhus
  */
-"use strict";
 
-const chalk = require("chalk"),
-    stripAnsi = require("strip-ansi"),
-    table = require("text-table");
+const chalk = require('chalk')
+const stripAnsi = require('strip-ansi')
+const table = require('text-table')
 
 //------------------------------------------------------------------------------
 // Helpers
@@ -19,83 +18,100 @@ const chalk = require("chalk"),
  * @returns {string} The original word with an s on the end if count is not one.
  */
 function pluralize(word, count) {
-    return (count === 1 ? word : `${word}s`);
+  return count === 1 ? word : `${word}s`
 }
 
 //------------------------------------------------------------------------------
 // Public Interface
 //------------------------------------------------------------------------------
 
-module.exports = function(results) {
+module.exports = function (results) {
+  let output = '\n'
+  let errorCount = 0
+  let warningCount = 0
+  let fixableErrorCount = 0
+  let fixableWarningCount = 0
+  let summaryColor = 'yellow'
 
-    let output = "\n",
-        errorCount = 0,
-        warningCount = 0,
-        fixableErrorCount = 0,
-        fixableWarningCount = 0,
-        summaryColor = "yellow";
+  results.forEach((result) => {
+    const messages = result.messages
 
-    results.forEach(result => {
-        const messages = result.messages;
-
-        if (messages.length === 0) {
-            return;
-        }
-
-        errorCount += result.errorCount;
-        warningCount += result.warningCount;
-        fixableErrorCount += result.fixableErrorCount;
-        fixableWarningCount += result.fixableWarningCount;
-
-        output += `${chalk.underline(result.filePath)}\n`;
-
-        output += `${table(
-            messages.map(message => {
-                let messageType;
-
-                if (message.fatal || message.severity === 2) {
-                    messageType = chalk.red("error");
-                    summaryColor = "red";
-                } else {
-                    messageType = chalk.yellow("warning");
-                }
-
-                return [
-                    "",
-                    message.line || 0,
-                    message.column || 0,
-                    messageType,
-                    message.message.replace(/([^ ])\.$/u, "$1"),
-                    chalk.dim(message.ruleId || "")
-                ];
-            }),
-            {
-                align: ["", "r", "l"],
-                stringLength(str) {
-                    return stripAnsi(str).length;
-                }
-            }
-        ).split("\n").map(el => el.replace(/(\d+)\s+(\d+)/u, (m, p1, p2) => chalk.dim(`${p1}:${p2}`))).join("\n")}\n\n`;
-    });
-
-    const total = errorCount + warningCount;
-
-    if (total > 0) {
-        output += chalk[summaryColor].bold([
-            "\u2716 ", total, pluralize(" problem", total),
-            " (", errorCount, pluralize(" error", errorCount), ", ",
-            warningCount, pluralize(" warning", warningCount), ")\n"
-        ].join(""));
-
-        if (fixableErrorCount > 0 || fixableWarningCount > 0) {
-            output += chalk[summaryColor].bold([
-                "  ", fixableErrorCount, pluralize(" error", fixableErrorCount), " and ",
-                fixableWarningCount, pluralize(" warning", fixableWarningCount),
-                " potentially fixable with the `--fix` option.\n"
-            ].join(""));
-        }
+    if (messages.length === 0) {
+      return
     }
 
-    // Resets output color, for prevent change on top level
-    return total > 0 ? chalk.reset(output) : "";
-};
+    errorCount += result.errorCount
+    warningCount += result.warningCount
+    fixableErrorCount += result.fixableErrorCount
+    fixableWarningCount += result.fixableWarningCount
+
+    output += `${chalk.underline(result.filePath)}\n`
+
+    output += `${table(
+      messages.map((message) => {
+        let messageType
+
+        if (message.fatal || message.severity === 2) {
+          messageType = chalk.red('error')
+          summaryColor = 'red'
+        } else {
+          messageType = chalk.yellow('warning')
+        }
+
+        return [
+          '',
+          message.line || 0,
+          message.column || 0,
+          messageType,
+          message.message.replace(/([^ ])\.$/u, '$1'),
+          chalk.dim(message.ruleId || ''),
+        ]
+      }),
+      {
+        align: ['', 'r', 'l'],
+        stringLength(str) {
+          return stripAnsi(str).length
+        },
+      }
+    )
+      .split('\n')
+      .map((el) => el.replace(/(\d+)\s+(\d+)/u, (m, p1, p2) => chalk.dim(`${p1}:${p2}`)))
+      .join('\n')}\n\n`
+  })
+
+  const total = errorCount + warningCount
+
+  if (total > 0) {
+    output += chalk[summaryColor].bold(
+      [
+        '\u2716 ',
+        total,
+        pluralize(' problem', total),
+        ' (',
+        errorCount,
+        pluralize(' error', errorCount),
+        ', ',
+        warningCount,
+        pluralize(' warning', warningCount),
+        ')\n',
+      ].join('')
+    )
+
+    if (fixableErrorCount > 0 || fixableWarningCount > 0) {
+      output += chalk[summaryColor].bold(
+        [
+          '  ',
+          fixableErrorCount,
+          pluralize(' error', fixableErrorCount),
+          ' and ',
+          fixableWarningCount,
+          pluralize(' warning', fixableWarningCount),
+          ' potentially fixable with the `--fix` option.\n',
+        ].join('')
+      )
+    }
+  }
+
+  // Resets output color, for prevent change on top level
+  return total > 0 ? chalk.reset(output) : ''
+}

--- a/lib/formatters/table.js
+++ b/lib/formatters/table.js
@@ -2,15 +2,14 @@
  * @fileoverview "table reporter.
  * @author Gajus Kuizinas <gajus@gajus.com>
  */
-"use strict";
 
 //------------------------------------------------------------------------------
 // Requirements
 //------------------------------------------------------------------------------
 
-const chalk = require("chalk"),
-    table = require("table").table,
-    pluralize = require("pluralize");
+const chalk = require('chalk')
+const table = require('table').table
+const pluralize = require('pluralize')
 
 //------------------------------------------------------------------------------
 // Helpers
@@ -22,66 +21,66 @@ const chalk = require("chalk"),
  * @returns {string} A text table.
  */
 function drawTable(messages) {
-    const rows = [];
+  const rows = []
 
-    if (messages.length === 0) {
-        return "";
+  if (messages.length === 0) {
+    return ''
+  }
+
+  rows.push([
+    chalk.bold('Line'),
+    chalk.bold('Column'),
+    chalk.bold('Type'),
+    chalk.bold('Message'),
+    chalk.bold('Rule ID'),
+  ])
+
+  messages.forEach((message) => {
+    let messageType
+
+    if (message.fatal || message.severity === 2) {
+      messageType = chalk.red('error')
+    } else {
+      messageType = chalk.yellow('warning')
     }
 
     rows.push([
-        chalk.bold("Line"),
-        chalk.bold("Column"),
-        chalk.bold("Type"),
-        chalk.bold("Message"),
-        chalk.bold("Rule ID")
-    ]);
+      message.line || 0,
+      message.column || 0,
+      messageType,
+      message.message,
+      message.ruleId || '',
+    ])
+  })
 
-    messages.forEach(message => {
-        let messageType;
-
-        if (message.fatal || message.severity === 2) {
-            messageType = chalk.red("error");
-        } else {
-            messageType = chalk.yellow("warning");
-        }
-
-        rows.push([
-            message.line || 0,
-            message.column || 0,
-            messageType,
-            message.message,
-            message.ruleId || ""
-        ]);
-    });
-
-    return table(rows, {
-        columns: {
-            0: {
-                width: 8,
-                wrapWord: true
-            },
-            1: {
-                width: 8,
-                wrapWord: true
-            },
-            2: {
-                width: 8,
-                wrapWord: true
-            },
-            3: {
-                paddingRight: 5,
-                width: 50,
-                wrapWord: true
-            },
-            4: {
-                width: 20,
-                wrapWord: true
-            }
-        },
-        drawHorizontalLine(index) {
-            return index === 1;
-        }
-    });
+  return table(rows, {
+    columns: {
+      0: {
+        width: 8,
+        wrapWord: true,
+      },
+      1: {
+        width: 8,
+        wrapWord: true,
+      },
+      2: {
+        width: 8,
+        wrapWord: true,
+      },
+      3: {
+        paddingRight: 5,
+        width: 50,
+        wrapWord: true,
+      },
+      4: {
+        width: 20,
+        wrapWord: true,
+      },
+    },
+    drawHorizontalLine(index) {
+      return index === 1
+    },
+  })
 }
 
 /**
@@ -90,61 +89,60 @@ function drawTable(messages) {
  * @returns {string} A column of text tables.
  */
 function drawReport(results) {
-    let files;
+  let files
 
-    files = results.map(result => {
-        if (!result.messages.length) {
-            return "";
-        }
+  files = results.map((result) => {
+    if (!result.messages.length) {
+      return ''
+    }
 
-        return `\n${result.filePath}\n\n${drawTable(result.messages)}`;
-    });
+    return `\n${result.filePath}\n\n${drawTable(result.messages)}`
+  })
 
-    files = files.filter(content => content.trim());
+  files = files.filter((content) => content.trim())
 
-    return files.join("");
+  return files.join('')
 }
 
 //------------------------------------------------------------------------------
 // Public Interface
 //------------------------------------------------------------------------------
 
-module.exports = function(report) {
-    let result,
-        errorCount,
-        warningCount;
+module.exports = function (report) {
+  let result
+  let errorCount
+  let warningCount
 
-    result = "";
-    errorCount = 0;
-    warningCount = 0;
+  result = ''
+  errorCount = 0
+  warningCount = 0
 
-    report.forEach(fileReport => {
-        errorCount += fileReport.errorCount;
-        warningCount += fileReport.warningCount;
-    });
+  report.forEach((fileReport) => {
+    errorCount += fileReport.errorCount
+    warningCount += fileReport.warningCount
+  })
 
-    if (errorCount || warningCount) {
-        result = drawReport(report);
-    }
+  if (errorCount || warningCount) {
+    result = drawReport(report)
+  }
 
-    result += `\n${table([
-        [
-            chalk.red(pluralize("Error", errorCount, true))
-        ],
-        [
-            chalk.yellow(pluralize("Warning", warningCount, true))
-        ]
-    ], {
-        columns: {
-            0: {
-                width: 110,
-                wrapWord: true
-            }
+  result += `\n${table(
+    [
+      [chalk.red(pluralize('Error', errorCount, true))],
+      [chalk.yellow(pluralize('Warning', warningCount, true))],
+    ],
+    {
+      columns: {
+        0: {
+          width: 110,
+          wrapWord: true,
         },
-        drawHorizontalLine() {
-            return true;
-        }
-    })}`;
+      },
+      drawHorizontalLine() {
+        return true
+      },
+    }
+  )}`
 
-    return result;
-};
+  return result
+}

--- a/lib/formatters/tap.js
+++ b/lib/formatters/tap.js
@@ -2,9 +2,8 @@
  * @fileoverview TAP reporter
  * @author Jonathan Kingston
  */
-"use strict";
 
-const yaml = require("js-yaml");
+const yaml = require('js-yaml')
 
 //------------------------------------------------------------------------------
 // Helper Functions
@@ -16,10 +15,10 @@ const yaml = require("js-yaml");
  * @returns {string} Error level string
  */
 function getMessageType(message) {
-    if (message.fatal || message.severity === 2) {
-        return "error";
-    }
-    return "warning";
+  if (message.fatal || message.severity === 2) {
+    return 'error'
+  }
+  return 'warning'
 }
 
 /**
@@ -28,68 +27,67 @@ function getMessageType(message) {
  * @returns {string} diagnostics string with YAML embedded - TAP version 13 compliant
  */
 function outputDiagnostics(diagnostic) {
-    const prefix = "  ";
-    let output = `${prefix}---\n`;
+  const prefix = '  '
+  let output = `${prefix}---\n`
 
-    output += prefix + yaml.dump(diagnostic).split("\n").join(`\n${prefix}`);
-    output += "...\n";
-    return output;
+  output += prefix + yaml.dump(diagnostic).split('\n').join(`\n${prefix}`)
+  output += '...\n'
+  return output
 }
 
 //------------------------------------------------------------------------------
 // Public Interface
 //------------------------------------------------------------------------------
 
-module.exports = function(results) {
-    let output = `TAP version 13\n1..${results.length}\n`;
+module.exports = function (results) {
+  let output = `TAP version 13\n1..${results.length}\n`
 
-    results.forEach((result, id) => {
-        const messages = result.messages;
-        let testResult = "ok";
-        let diagnostics = {};
+  results.forEach((result, id) => {
+    const messages = result.messages
+    let testResult = 'ok'
+    let diagnostics = {}
 
-        if (messages.length > 0) {
-            messages.forEach(message => {
-                const severity = getMessageType(message);
-                const diagnostic = {
-                    message: message.message,
-                    severity,
-                    data: {
-                        line: message.line || 0,
-                        column: message.column || 0,
-                        ruleId: message.ruleId || ""
-                    }
-                };
-
-                // This ensures a warning message is not flagged as error
-                if (severity === "error") {
-                    testResult = "not ok";
-                }
-
-                /*
-                 * If we have multiple messages place them under a messages key
-                 * The first error will be logged as message key
-                 * This is to adhere to TAP 13 loosely defined specification of having a message key
-                 */
-                if ("message" in diagnostics) {
-                    if (typeof diagnostics.messages === "undefined") {
-                        diagnostics.messages = [];
-                    }
-                    diagnostics.messages.push(diagnostic);
-                } else {
-                    diagnostics = diagnostic;
-                }
-            });
+    if (messages.length > 0) {
+      messages.forEach((message) => {
+        const severity = getMessageType(message)
+        const diagnostic = {
+          message: message.message,
+          severity,
+          data: {
+            line: message.line || 0,
+            column: message.column || 0,
+            ruleId: message.ruleId || '',
+          },
         }
 
-        output += `${testResult} ${id + 1} - ${result.filePath}\n`;
-
-        // If we have an error include diagnostics
-        if (messages.length > 0) {
-            output += outputDiagnostics(diagnostics);
+        // This ensures a warning message is not flagged as error
+        if (severity === 'error') {
+          testResult = 'not ok'
         }
 
-    });
+        /*
+         * If we have multiple messages place them under a messages key
+         * The first error will be logged as message key
+         * This is to adhere to TAP 13 loosely defined specification of having a message key
+         */
+        if ('message' in diagnostics) {
+          if (typeof diagnostics.messages === 'undefined') {
+            diagnostics.messages = []
+          }
+          diagnostics.messages.push(diagnostic)
+        } else {
+          diagnostics = diagnostic
+        }
+      })
+    }
 
-    return output;
-};
+    output += `${testResult} ${id + 1} - ${result.filePath}\n`
+
+    // If we have an error include diagnostics
+    if (messages.length > 0) {
+      output += outputDiagnostics(diagnostics)
+    }
+  })
+
+  return output
+}

--- a/lib/formatters/unix.js
+++ b/lib/formatters/unix.js
@@ -2,7 +2,6 @@
  * @fileoverview unix-style formatter.
  * @author oshi-shinobu
  */
-"use strict";
 
 //------------------------------------------------------------------------------
 // Helper Functions
@@ -14,45 +13,38 @@
  * @returns {string} Error level string
  */
 function getMessageType(message) {
-    if (message.fatal || message.severity === 2) {
-        return "Error";
-    }
-    return "Warning";
-
+  if (message.fatal || message.severity === 2) {
+    return 'Error'
+  }
+  return 'Warning'
 }
-
 
 //------------------------------------------------------------------------------
 // Public Interface
 //------------------------------------------------------------------------------
 
-module.exports = function(results) {
+module.exports = function (results) {
+  let output = ''
+  let total = 0
 
-    let output = "",
-        total = 0;
+  results.forEach((result) => {
+    const messages = result.messages
 
-    results.forEach(result => {
+    total += messages.length
 
-        const messages = result.messages;
+    messages.forEach((message) => {
+      output += `${result.filePath}:`
+      output += `${message.line || 0}:`
+      output += `${message.column || 0}:`
+      output += ` ${message.message} `
+      output += `[${getMessageType(message)}${message.ruleId ? `/${message.ruleId}` : ''}]`
+      output += '\n'
+    })
+  })
 
-        total += messages.length;
+  if (total > 0) {
+    output += `\n${total} problem${total !== 1 ? 's' : ''}`
+  }
 
-        messages.forEach(message => {
-
-            output += `${result.filePath}:`;
-            output += `${message.line || 0}:`;
-            output += `${message.column || 0}:`;
-            output += ` ${message.message} `;
-            output += `[${getMessageType(message)}${message.ruleId ? `/${message.ruleId}` : ""}]`;
-            output += "\n";
-
-        });
-
-    });
-
-    if (total > 0) {
-        output += `\n${total} problem${total !== 1 ? "s" : ""}`;
-    }
-
-    return output;
-};
+  return output
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -59,12 +59,12 @@ function processFile(file, config) {
 }
 
 function processPath(path, config) {
-  const ignoreFilter = ignore({allowRelativePaths: true}).add(config.excludedFiles)
+  const ignoreFilter = ignore({ allowRelativePaths: true }).add(config.excludedFiles)
 
   const allFiles = glob.sync(path, {})
   const files = ignoreFilter.filter(allFiles)
 
-  return files.map(curFile => processFile(curFile, config))
+  return files.map((curFile) => processFile(curFile, config))
 }
 
 module.exports = { processPath, processFile, processStr }

--- a/lib/load-rules.js
+++ b/lib/load-rules.js
@@ -11,7 +11,7 @@ const loadRules = () => {
   const rules = []
   const files = walkSync(rulesDir)
 
-  const filesFiltered = files.filter(file => {
+  const filesFiltered = files.filter((file) => {
     const filename = path.parse(file).base
     return path.extname(filename) === '.js' && !blacklistedFiles.includes(filename)
   })
@@ -33,12 +33,12 @@ const loadRules = () => {
   return rules
 }
 
-const loadRule = rule => {
+const loadRule = (rule) => {
   const rulesDir = path.join(__dirname, 'rules')
   let fileInstance
   const files = walkSync(rulesDir)
 
-  const filesFiltered = files.filter(file => {
+  const filesFiltered = files.filter((file) => {
     const filename = path.parse(file).base
     return path.extname(filename) === '.js' && !blacklistedFiles.includes(filename)
   })
@@ -63,5 +63,5 @@ const loadRule = rule => {
 
 module.exports = {
   loadRules,
-  loadRule
+  loadRule,
 }

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -66,7 +66,7 @@ class Reporter {
   }
 
   _countReportsWith(severity) {
-    return this.reports.filter(i => i.severity === severity).length
+    return this.reports.filter((i) => i.severity === severity).length
   }
 
   get messages() {

--- a/lib/rule-fixer.js
+++ b/lib/rule-fixer.js
@@ -25,7 +25,7 @@
 function insertTextAt(index, text) {
   return {
     range: [index, index],
-    text
+    text,
   }
 }
 
@@ -106,7 +106,7 @@ const ruleFixer = Object.freeze({
   replaceTextRange(range, text) {
     return {
       range,
-      text
+      text,
     }
   },
 
@@ -130,9 +130,9 @@ const ruleFixer = Object.freeze({
   removeRange(range) {
     return {
       range,
-      text: ''
+      text: '',
     }
-  }
+  },
 })
 
 module.exports = ruleFixer

--- a/lib/rules/base-checker.js
+++ b/lib/rules/base-checker.js
@@ -1,15 +1,15 @@
 const chalk = require('chalk')
 const Ajv = require('ajv')
 
-const ruleConfigSchema = schema => {
+const ruleConfigSchema = (schema) => {
   const baseSchema = {
     type: 'array',
     items: [
       {
-        enum: ['error', 'warn', 'off']
-      }
+        enum: ['error', 'warn', 'off'],
+      },
     ],
-    minItems: 1
+    minItems: 1,
   }
 
   if (schema) {
@@ -38,9 +38,9 @@ class BaseChecker {
         const validate = ajv.compile(schema)
         if (!validate(userConfig)) {
           const messages = validate.errors
-            .map(e => e.message)
-            .filter(x => x) // filter out possible missing messages
-            .map(x => `  ${x}`) // indent
+            .map((e) => e.message)
+            .filter((x) => x) // filter out possible missing messages
+            .map((x) => `  ${x}`) // indent
             .join('\n')
 
           console.warn(

--- a/lib/rules/best-practises/code-complexity.js
+++ b/lib/rules/best-practises/code-complexity.js
@@ -1,4 +1,4 @@
-const BaseChecker = require('./../base-checker')
+const BaseChecker = require('../base-checker')
 const { severityDescription } = require('../../doc/utils')
 
 const ruleId = 'code-complexity'
@@ -13,34 +13,34 @@ const meta = {
     options: [
       {
         description: severityDescription,
-        default: DEFAULT_SEVERITY
+        default: DEFAULT_SEVERITY,
       },
       {
         description: 'Maximum allowed cyclomatic complexity',
-        default: DEFAULT_COMPLEXITY
-      }
+        default: DEFAULT_COMPLEXITY,
+      },
     ],
     examples: {
       good: [
         {
           description: 'Low code complexity',
-          code: require('../../../test/fixtures/best-practises/code-complexity-low')
-        }
+          code: require('../../../test/fixtures/best-practises/code-complexity-low'),
+        },
       ],
       bad: [
         {
           description: 'High code complexity',
-          code: require('../../../test/fixtures/best-practises/code-complexity-high')
-        }
-      ]
-    }
+          code: require('../../../test/fixtures/best-practises/code-complexity-high'),
+        },
+      ],
+    },
   },
 
   isDefault: false,
   recommended: false,
   defaultSetup: [DEFAULT_SEVERITY, DEFAULT_COMPLEXITY],
 
-  schema: { type: 'integer' }
+  schema: { type: 'integer' },
 }
 
 class CodeComplexityChecker extends BaseChecker {

--- a/lib/rules/best-practises/function-max-lines.js
+++ b/lib/rules/best-practises/function-max-lines.js
@@ -1,4 +1,4 @@
-const BaseChecker = require('./../base-checker')
+const BaseChecker = require('../base-checker')
 const { severityDescription } = require('../../doc/utils')
 
 const DEFAULT_SEVERITY = 'warn'
@@ -13,13 +13,13 @@ const meta = {
     options: [
       {
         description: severityDescription,
-        default: DEFAULT_SEVERITY
+        default: DEFAULT_SEVERITY,
       },
       {
         description: 'Maximum allowed lines count per function',
-        default: DEFAULT_MAX_LINES_COUNT
-      }
-    ]
+        default: DEFAULT_MAX_LINES_COUNT,
+      },
+    ],
   },
 
   isDefault: false,
@@ -28,8 +28,8 @@ const meta = {
 
   schema: {
     type: 'integer',
-    minimum: 1
-  }
+    minimum: 1,
+  },
 }
 
 class FunctionMaxLinesChecker extends BaseChecker {
@@ -66,9 +66,7 @@ class FunctionMaxLinesChecker extends BaseChecker {
 
   _error(node) {
     const linesCount = this._linesCount(node)
-    const message = `Function body contains ${linesCount} lines but allowed no more than ${
-      this.maxLines
-    } lines`
+    const message = `Function body contains ${linesCount} lines but allowed no more than ${this.maxLines} lines`
     this.error(node, message)
   }
 }

--- a/lib/rules/best-practises/index.js
+++ b/lib/rules/best-practises/index.js
@@ -16,6 +16,6 @@ module.exports = function checkers(reporter, config, inputSrc) {
     new NoEmptyBlocksChecker(reporter),
     new NoUnusedVarsChecker(reporter),
     new PayableFallbackChecker(reporter),
-    new ReasonStringChecker(reporter, config)
+    new ReasonStringChecker(reporter, config),
   ]
 }

--- a/lib/rules/best-practises/max-line-length.js
+++ b/lib/rules/best-practises/max-line-length.js
@@ -1,4 +1,4 @@
-const BaseChecker = require('./../base-checker')
+const BaseChecker = require('../base-checker')
 const { severityDescription } = require('../../doc/utils')
 
 const lineBreakPattern = /\r\n|[\r\n\u2028\u2029]/u
@@ -15,20 +15,20 @@ const meta = {
     options: [
       {
         description: severityDescription,
-        default: DEFAULT_SEVERITY
+        default: DEFAULT_SEVERITY,
       },
       {
         description: 'Maximum allowed number of characters per line',
-        default: DEFAULT_MAX_LINE_LENGTH
-      }
-    ]
+        default: DEFAULT_MAX_LINE_LENGTH,
+      },
+    ],
   },
 
   isDefault: true,
   recommended: false,
   defaultSetup: [DEFAULT_SEVERITY, DEFAULT_MAX_LINE_LENGTH],
 
-  schema: { type: 'integer', minimum: 1 }
+  schema: { type: 'integer', minimum: 1 },
 }
 
 class MaxLineLengthChecker extends BaseChecker {
@@ -41,14 +41,12 @@ class MaxLineLengthChecker extends BaseChecker {
 
   SourceUnit() {
     const lines = this.inputSrc.split(lineBreakPattern)
-    lines.map(line => line.length).forEach(this.validateLineLength.bind(this))
+    lines.map((line) => line.length).forEach(this.validateLineLength.bind(this))
   }
 
   validateLineLength(curLength, lineNum) {
     if (curLength > this.maxLength) {
-      const message = `Line length must be no more than ${
-        this.maxLength
-      } but current length is ${curLength}.`
+      const message = `Line length must be no more than ${this.maxLength} but current length is ${curLength}.`
       this.errorAt(lineNum + 1, 1, message)
     }
   }

--- a/lib/rules/best-practises/max-states-count.js
+++ b/lib/rules/best-practises/max-states-count.js
@@ -1,5 +1,5 @@
 const _ = require('lodash')
-const BaseChecker = require('./../base-checker')
+const BaseChecker = require('../base-checker')
 const { severityDescription } = require('../../doc/utils')
 
 const ruleId = 'max-states-count'
@@ -15,34 +15,34 @@ const meta = {
     options: [
       {
         description: severityDescription,
-        default: DEFAULT_SEVERITY
+        default: DEFAULT_SEVERITY,
       },
       {
         description: 'Maximum allowed number of states declarations',
-        default: DEFAULT_MAX_STATES_COUNT
-      }
+        default: DEFAULT_MAX_STATES_COUNT,
+      },
     ],
     examples: {
       good: [
         {
           description: 'Low number of states',
-          code: require('../../../test/fixtures/best-practises/number-of-states-low')
-        }
+          code: require('../../../test/fixtures/best-practises/number-of-states-low'),
+        },
       ],
       bad: [
         {
           description: 'High number of states',
-          code: require('../../../test/fixtures/best-practises/number-of-states-high')
-        }
-      ]
-    }
+          code: require('../../../test/fixtures/best-practises/number-of-states-high'),
+        },
+      ],
+    },
   },
 
   isDefault: false,
   recommended: true,
   defaultSetup: [DEFAULT_SEVERITY, DEFAULT_MAX_STATES_COUNT],
 
-  schema: { type: 'integer' }
+  schema: { type: 'integer' },
 }
 
 class MaxStatesCountChecker extends BaseChecker {

--- a/lib/rules/best-practises/no-empty-blocks.js
+++ b/lib/rules/best-practises/no-empty-blocks.js
@@ -1,5 +1,5 @@
-const BaseChecker = require('./../base-checker')
-const { isFallbackFunction } = require('./../../common/ast-types')
+const BaseChecker = require('../base-checker')
+const { isFallbackFunction } = require('../../common/ast-types')
 
 const ruleId = 'no-empty-blocks'
 const meta = {
@@ -7,14 +7,14 @@ const meta = {
 
   docs: {
     description: 'Code contains empty block.',
-    category: 'Best Practise Rules'
+    category: 'Best Practise Rules',
   },
 
   isDefault: false,
   recommended: true,
   defaultSetup: 'warn',
 
-  schema: null
+  schema: null,
 }
 
 class NoEmptyBlocksChecker extends BaseChecker {

--- a/lib/rules/best-practises/no-unused-vars.js
+++ b/lib/rules/best-practises/no-unused-vars.js
@@ -1,6 +1,6 @@
 const _ = require('lodash')
-const BaseChecker = require('./../base-checker')
-const TreeTraversing = require('./../../common/tree-traversing')
+const BaseChecker = require('../base-checker')
+const TreeTraversing = require('../../common/tree-traversing')
 
 const traversing = new TreeTraversing()
 
@@ -10,14 +10,14 @@ const meta = {
 
   docs: {
     description: 'Variable "name" is unused.',
-    category: 'Best Practise Rules'
+    category: 'Best Practise Rules',
   },
 
   isDefault: false,
   recommended: true,
   defaultSetup: 'warn',
 
-  schema: null
+  schema: null,
 }
 
 class NoUnusedVarsChecker extends BaseChecker {
@@ -31,18 +31,20 @@ class NoUnusedVarsChecker extends BaseChecker {
 
     if (!ignoreWhen(funcWithoutBlock, emptyBlock)) {
       VarUsageScope.activate(node)
-      node.parameters.filter(parameter => parameter.name).forEach(parameter => {
-        this._addVariable(parameter)
-      })
+      node.parameters
+        .filter((parameter) => parameter.name)
+        .forEach((parameter) => {
+          this._addVariable(parameter)
+        })
     }
   }
 
   VariableDeclarationStatement(node) {
-    node.variables.forEach(variable => this._addVariable(variable))
+    node.variables.forEach((variable) => this._addVariable(variable))
   }
 
   AssemblyLocalDefinition(node) {
-    node.names.forEach(variable => this._addVariable(variable))
+    node.names.forEach((variable) => this._addVariable(variable))
   }
 
   Identifier(node) {
@@ -83,9 +85,7 @@ class NoUnusedVarsChecker extends BaseChecker {
   }
 
   _reportErrorsFor(node) {
-    VarUsageScope.of(node)
-      .unusedVariables()
-      .forEach(this._error.bind(this))
+    VarUsageScope.of(node).unusedVariables().forEach(this._error.bind(this))
   }
 
   _error({ name, node }) {
@@ -147,7 +147,7 @@ class VarUsageScope {
 
   unusedVariables() {
     return _(this.vars)
-      .pickBy(val => val.usage === 0)
+      .pickBy((val) => val.usage === 0)
       .map((info, varName) => ({ name: varName, node: info.node }))
       .value()
   }

--- a/lib/rules/best-practises/payable-fallback.js
+++ b/lib/rules/best-practises/payable-fallback.js
@@ -1,4 +1,4 @@
-const BaseChecker = require('./../base-checker')
+const BaseChecker = require('../base-checker')
 const { isFallbackFunction } = require('../../common/ast-types')
 
 const ruleId = 'payable-fallback'
@@ -12,23 +12,23 @@ const meta = {
       good: [
         {
           description: 'Fallback is payable',
-          code: require('../../../test/fixtures/best-practises/fallback-payable')
-        }
+          code: require('../../../test/fixtures/best-practises/fallback-payable'),
+        },
       ],
       bad: [
         {
           description: 'Fallback is not payable',
-          code: require('../../../test/fixtures/best-practises/fallback-not-payable')
-        }
-      ]
-    }
+          code: require('../../../test/fixtures/best-practises/fallback-not-payable'),
+        },
+      ],
+    },
   },
 
   isDefault: false,
   recommended: true,
   defaultSetup: 'warn',
 
-  schema: null
+  schema: null,
 }
 
 class PayableFallbackChecker extends BaseChecker {

--- a/lib/rules/best-practises/reason-string.js
+++ b/lib/rules/best-practises/reason-string.js
@@ -1,5 +1,5 @@
 const _ = require('lodash')
-const BaseChecker = require('./../base-checker')
+const BaseChecker = require('../base-checker')
 const { severityDescription } = require('../../doc/utils')
 
 const DEFAULT_SEVERITY = 'warn'
@@ -17,28 +17,28 @@ const meta = {
     options: [
       {
         description: severityDescription,
-        default: DEFAULT_SEVERITY
+        default: DEFAULT_SEVERITY,
       },
       {
         description:
           'A JSON object with a single property "maxLength" specifying the max number of characters per reason string.',
-        default: JSON.stringify(DEFAULT_OPTION)
-      }
+        default: JSON.stringify(DEFAULT_OPTION),
+      },
     ],
     examples: {
       good: [
         {
           description: 'Require with reason string',
-          code: require('../../../test/fixtures/best-practises/require-with-reason')
-        }
+          code: require('../../../test/fixtures/best-practises/require-with-reason'),
+        },
       ],
       bad: [
         {
           description: 'Require without reason string',
-          code: require('../../../test/fixtures/best-practises/require-without-reason')
-        }
-      ]
-    }
+          code: require('../../../test/fixtures/best-practises/require-without-reason'),
+        },
+      ],
+    },
   },
 
   isDefault: false,
@@ -49,10 +49,10 @@ const meta = {
     type: 'object',
     properties: {
       maxLength: {
-        type: 'integer'
-      }
-    }
-  }
+        type: 'integer',
+      },
+    },
+  },
 }
 
 class ReasonStringChecker extends BaseChecker {

--- a/lib/rules/deprecations/base-deprecation.js
+++ b/lib/rules/deprecations/base-deprecation.js
@@ -1,4 +1,4 @@
-const BaseChecker = require('./../base-checker')
+const BaseChecker = require('../base-checker')
 
 class BaseDeprecation extends BaseChecker {
   constructor(reporter, ruleId, meta) {

--- a/lib/rules/deprecations/constructor-syntax.js
+++ b/lib/rules/deprecations/constructor-syntax.js
@@ -6,14 +6,14 @@ const meta = {
 
   docs: {
     description: 'Constructors should use the new constructor keyword.',
-    category: 'Best Practise Rules'
+    category: 'Best Practise Rules',
   },
 
   isDefault: false,
   recommended: false,
   defaultSetup: 'warn',
 
-  schema: null
+  schema: null,
 }
 
 class ConstructorSyntax extends BaseDeprecation {

--- a/lib/rules/deprecations/index.js
+++ b/lib/rules/deprecations/index.js
@@ -1,3 +1,3 @@
 const ConstructorSyntax = require('./constructor-syntax')
 
-module.exports = reporter => [new ConstructorSyntax(reporter)]
+module.exports = (reporter) => [new ConstructorSyntax(reporter)]

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -6,7 +6,7 @@ const order = require('./order/index')
 const bestPractises = require('./best-practises/index')
 const deprecations = require('./deprecations/index')
 const miscellaneous = require('./miscellaneous/index')
-const configObject = require('./../config')
+const configObject = require('../config')
 const { validSeverityMap } = require('../config/config-validator')
 
 const notifyRuleDeprecated = _.memoize((ruleId, deprecationMessage) => {
@@ -16,7 +16,7 @@ const notifyRuleDeprecated = _.memoize((ruleId, deprecationMessage) => {
   console.warn(chalk.yellow(message))
 })
 
-const notifyRuleDoesntExist = _.memoize(ruleId => {
+const notifyRuleDoesntExist = _.memoize((ruleId) => {
   console.warn(chalk.yellow(`[solhint] Warning: Rule '${ruleId}' doesn't exist`))
 })
 
@@ -28,13 +28,13 @@ module.exports = function checkers(reporter, configVals, inputSrc, tokens, fileN
     config,
     inputSrc,
     tokens,
-    fileName
+    fileName,
   }
   const plugins = config.plugins || []
 
   const allRules = [...coreRules(meta), ...pluginsRules(plugins, meta)]
 
-  const enabledRules = allRules.filter(coreRule => ruleEnabled(coreRule, rules))
+  const enabledRules = allRules.filter((coreRule) => ruleEnabled(coreRule, rules))
 
   // show warnings for deprecated rules
   for (const rule of enabledRules) {
@@ -44,7 +44,7 @@ module.exports = function checkers(reporter, configVals, inputSrc, tokens, fileN
   }
 
   const configRules = Object.keys(config.rules)
-  const allRuleIds = allRules.map(rule => rule.ruleId)
+  const allRuleIds = allRules.map((rule) => rule.ruleId)
   for (const rule of configRules) {
     if (!allRuleIds.includes(rule)) {
       notifyRuleDoesntExist(rule)
@@ -63,7 +63,7 @@ function coreRules(meta) {
     ...miscellaneous(reporter, config, tokens),
     ...naming(reporter, config),
     ...order(reporter, tokens),
-    ...security(reporter, config, inputSrc)
+    ...security(reporter, config, inputSrc),
   ]
 }
 
@@ -89,17 +89,19 @@ function loadPlugin(pluginName, { reporter, config, inputSrc, fileName }) {
     return []
   }
 
-  return plugins.map(Plugin => new Plugin(reporter, config, inputSrc, fileName)).map(plugin => {
-    plugin.ruleId = `${pluginName}/${plugin.ruleId}`
-    return plugin
-  })
+  return plugins
+    .map((Plugin) => new Plugin(reporter, config, inputSrc, fileName))
+    .map((plugin) => {
+      plugin.ruleId = `${pluginName}/${plugin.ruleId}`
+      return plugin
+    })
 }
 
 function pluginsRules(configPlugins, meta) {
   const plugins = Array.isArray(configPlugins) ? configPlugins : [configPlugins]
 
   return _(plugins)
-    .map(name => loadPlugin(name, meta))
+    .map((name) => loadPlugin(name, meta))
     .flatten()
     .value()
 }

--- a/lib/rules/miscellaneous/comprehensive-interface.js
+++ b/lib/rules/miscellaneous/comprehensive-interface.js
@@ -1,4 +1,4 @@
-const BaseChecker = require('./../base-checker')
+const BaseChecker = require('../base-checker')
 
 const ruleId = 'comprehensive-interface'
 const meta = {
@@ -12,23 +12,23 @@ const meta = {
       good: [
         {
           description: 'All public functions are overrides',
-          code: require('../../../test/fixtures/miscellaneous/public-function-with-override')
-        }
+          code: require('../../../test/fixtures/miscellaneous/public-function-with-override'),
+        },
       ],
       bad: [
         {
           description: 'A public function is not an override',
-          code: require('../../../test/fixtures/miscellaneous/public-function-no-override')
-        }
-      ]
-    }
+          code: require('../../../test/fixtures/miscellaneous/public-function-no-override'),
+        },
+      ],
+    },
   },
 
   isDefault: false,
   recommended: false,
   defaultSetup: 'warn',
 
-  schema: null
+  schema: null,
 }
 
 class ComprehensiveInterface extends BaseChecker {

--- a/lib/rules/miscellaneous/index.js
+++ b/lib/rules/miscellaneous/index.js
@@ -4,6 +4,6 @@ const ComprehensiveInterfaceChecker = require('./comprehensive-interface')
 module.exports = function checkers(reporter, config, tokens) {
   return [
     new QuotesChecker(reporter, config, tokens),
-    new ComprehensiveInterfaceChecker(reporter, config, tokens)
+    new ComprehensiveInterfaceChecker(reporter, config, tokens),
   ]
 }

--- a/lib/rules/miscellaneous/quotes.js
+++ b/lib/rules/miscellaneous/quotes.js
@@ -14,27 +14,27 @@ const meta = {
     options: [
       {
         description: severityDescription,
-        default: DEFAULT_SEVERITY
+        default: DEFAULT_SEVERITY,
       },
       {
         description: `Type of quotes. Must be one of ${formatEnum(QUOTE_TYPES)}`,
-        default: DEFAULT_QUOTES_TYPE
-      }
+        default: DEFAULT_QUOTES_TYPE,
+      },
     ],
     examples: {
       good: [
         {
           description: 'String with double quotes',
-          code: require('../../../test/fixtures/miscellaneous/string-with-double-quotes')
-        }
+          code: require('../../../test/fixtures/miscellaneous/string-with-double-quotes'),
+        },
       ],
       bad: [
         {
           description: 'String with single quotes',
-          code: require('../../../test/fixtures/miscellaneous/string-with-single-quotes')
-        }
-      ]
-    }
+          code: require('../../../test/fixtures/miscellaneous/string-with-single-quotes'),
+        },
+      ],
+    },
   },
 
   isDefault: false,
@@ -43,8 +43,8 @@ const meta = {
 
   schema: {
     type: 'string',
-    enum: QUOTE_TYPES
-  }
+    enum: QUOTE_TYPES,
+  },
 }
 
 class QuotesChecker extends BaseChecker {
@@ -60,7 +60,7 @@ class QuotesChecker extends BaseChecker {
 
   StringLiteral(node) {
     const token = this.tokens.find(
-      token =>
+      (token) =>
         token.loc.start.line === node.loc.start.line &&
         token.loc.start.column === node.loc.start.column
     )
@@ -79,16 +79,16 @@ class QuotesChecker extends BaseChecker {
 
   alreadyVisited({
     loc: {
-      start: { line, column }
-    }
+      start: { line, column },
+    },
   }) {
     return this.visitedNodes.has(`${line}${column}`)
   }
 
   addVisitedNode({
     loc: {
-      start: { line, column }
-    }
+      start: { line, column },
+    },
   }) {
     this.visitedNodes.add(`${line}${column}`)
   }

--- a/lib/rules/naming/const-name-snakecase.js
+++ b/lib/rules/naming/const-name-snakecase.js
@@ -1,5 +1,5 @@
-const BaseChecker = require('./../base-checker')
-const naming = require('./../../common/identifier-naming')
+const BaseChecker = require('../base-checker')
+const naming = require('../../common/identifier-naming')
 
 const ruleId = 'const-name-snakecase'
 const meta = {
@@ -7,14 +7,14 @@ const meta = {
 
   docs: {
     description: 'Constant name must be in capitalized SNAKE_CASE.',
-    category: 'Style Guide Rules'
+    category: 'Style Guide Rules',
   },
 
   isDefault: false,
   recommended: true,
   defaultSetup: 'warn',
 
-  schema: null
+  schema: null,
 }
 
 class ConstNameSnakecaseChecker extends BaseChecker {

--- a/lib/rules/naming/contract-name-camelcase.js
+++ b/lib/rules/naming/contract-name-camelcase.js
@@ -1,5 +1,5 @@
-const BaseChecker = require('./../base-checker')
-const naming = require('./../../common/identifier-naming')
+const BaseChecker = require('../base-checker')
+const naming = require('../../common/identifier-naming')
 
 const ruleId = 'contract-name-camelcase'
 const meta = {
@@ -7,14 +7,14 @@ const meta = {
 
   docs: {
     description: 'Contract name must be in CamelCase.',
-    category: 'Style Guide Rules'
+    category: 'Style Guide Rules',
   },
 
   isDefault: false,
   recommended: true,
   defaultSetup: 'warn',
 
-  schema: null
+  schema: null,
 }
 
 class ContractNameCamelcaseChecker extends BaseChecker {

--- a/lib/rules/naming/event-name-camelcase.js
+++ b/lib/rules/naming/event-name-camelcase.js
@@ -1,5 +1,5 @@
-const BaseChecker = require('./../base-checker')
-const naming = require('./../../common/identifier-naming')
+const BaseChecker = require('../base-checker')
+const naming = require('../../common/identifier-naming')
 
 const ruleId = 'event-name-camelcase'
 const meta = {
@@ -7,14 +7,14 @@ const meta = {
 
   docs: {
     description: 'Event name must be in CamelCase.',
-    category: 'Style Guide Rules'
+    category: 'Style Guide Rules',
   },
 
   isDefault: false,
   recommended: true,
   defaultSetup: 'warn',
 
-  schema: null
+  schema: null,
 }
 
 class EventNameCamelcaseChecker extends BaseChecker {

--- a/lib/rules/naming/func-name-mixedcase.js
+++ b/lib/rules/naming/func-name-mixedcase.js
@@ -1,5 +1,5 @@
-const BaseChecker = require('./../base-checker')
-const naming = require('./../../common/identifier-naming')
+const BaseChecker = require('../base-checker')
+const naming = require('../../common/identifier-naming')
 
 const ruleId = 'func-name-mixedcase'
 const meta = {
@@ -7,14 +7,14 @@ const meta = {
 
   docs: {
     description: 'Function name must be in mixedCase.',
-    category: 'Style Guide Rules'
+    category: 'Style Guide Rules',
   },
 
   isDefault: false,
   recommended: true,
   defaultSetup: 'warn',
 
-  schema: null
+  schema: null,
 }
 
 class FuncNameMixedcaseChecker extends BaseChecker {

--- a/lib/rules/naming/func-param-name-mixedcase.js
+++ b/lib/rules/naming/func-param-name-mixedcase.js
@@ -1,5 +1,5 @@
-const BaseChecker = require('./../base-checker')
-const naming = require('./../../common/identifier-naming')
+const BaseChecker = require('../base-checker')
+const naming = require('../../common/identifier-naming')
 
 const ruleId = 'func-param-name-mixedcase'
 const meta = {
@@ -7,14 +7,14 @@ const meta = {
 
   docs: {
     description: 'Function param name must be in mixedCase',
-    category: 'Style Guide Rules'
+    category: 'Style Guide Rules',
   },
 
   isDefault: false,
   recommended: false,
   defaultSetup: 'warn',
 
-  schema: null
+  schema: null,
 }
 
 class FunctionParamNameMixedcaseChecker extends BaseChecker {
@@ -27,7 +27,7 @@ class FunctionParamNameMixedcaseChecker extends BaseChecker {
   }
 
   FunctionDefinition(node) {
-    node.parameters.forEach(parameter => {
+    node.parameters.forEach((parameter) => {
       if (naming.isNotMixedCase(parameter.name)) {
         this.error(parameter, 'Function param name must be in mixedCase')
       }

--- a/lib/rules/naming/index.js
+++ b/lib/rules/naming/index.js
@@ -18,6 +18,6 @@ module.exports = function checkers(reporter, config) {
     new ModifierNameMixedcaseChecker(reporter),
     new PrivateVarsLeadingUnderscore(reporter, config),
     new UseForbiddenNameChecker(reporter),
-    new VarNameMixedcaseChecker(reporter)
+    new VarNameMixedcaseChecker(reporter),
   ]
 }

--- a/lib/rules/naming/modifier-name-mixedcase.js
+++ b/lib/rules/naming/modifier-name-mixedcase.js
@@ -1,5 +1,5 @@
-const BaseChecker = require('./../base-checker')
-const naming = require('./../../common/identifier-naming')
+const BaseChecker = require('../base-checker')
+const naming = require('../../common/identifier-naming')
 
 const ruleId = 'modifier-name-mixedcase'
 const meta = {
@@ -7,14 +7,14 @@ const meta = {
 
   docs: {
     description: 'Modifier name must be in mixedCase.',
-    category: 'Style Guide Rules'
+    category: 'Style Guide Rules',
   },
 
   isDefault: false,
   recommended: false,
   defaultSetup: 'warn',
 
-  schema: null
+  schema: null,
 }
 
 class ModifierNameMixedcase extends BaseChecker {

--- a/lib/rules/naming/private-vars-leading-underscore.js
+++ b/lib/rules/naming/private-vars-leading-underscore.js
@@ -1,5 +1,5 @@
-const BaseChecker = require('./../base-checker')
-const naming = require('./../../common/identifier-naming')
+const BaseChecker = require('../base-checker')
+const naming = require('../../common/identifier-naming')
 const { severityDescription } = require('../../doc/utils')
 
 const DEFAULT_SEVERITY = 'warn'
@@ -16,14 +16,14 @@ const meta = {
     options: [
       {
         description: severityDescription,
-        default: DEFAULT_SEVERITY
+        default: DEFAULT_SEVERITY,
       },
       {
         description:
           'A JSON object with a single property "strict" specifying if the rule should apply to non state variables. Default: { strict: false }.',
-        default: JSON.stringify(DEFAULT_OPTION)
-      }
-    ]
+        default: JSON.stringify(DEFAULT_OPTION),
+      },
+    ],
   },
 
   isDefault: false,
@@ -34,10 +34,10 @@ const meta = {
     type: 'object',
     properties: {
       strict: {
-        type: 'boolean'
-      }
-    }
-  }
+        type: 'boolean',
+      },
+    },
+  },
 }
 
 class PrivateVarsLeadingUnderscoreChecker extends BaseChecker {

--- a/lib/rules/naming/use-forbidden-name.js
+++ b/lib/rules/naming/use-forbidden-name.js
@@ -1,4 +1,4 @@
-const BaseChecker = require('./../base-checker')
+const BaseChecker = require('../base-checker')
 
 const FORBIDDEN_NAMES = ['I', 'l', 'O']
 
@@ -8,14 +8,14 @@ const meta = {
 
   docs: {
     description: `Avoid to use letters 'I', 'l', 'O' as identifiers.`,
-    category: 'Style Guide Rules'
+    category: 'Style Guide Rules',
   },
 
   isDefault: false,
   recommended: true,
   defaultSetup: 'warn',
 
-  schema: null
+  schema: null,
 }
 
 class UseForbiddenNameChecker extends BaseChecker {

--- a/lib/rules/naming/var-name-mixedcase.js
+++ b/lib/rules/naming/var-name-mixedcase.js
@@ -1,5 +1,5 @@
-const BaseChecker = require('./../base-checker')
-const naming = require('./../../common/identifier-naming')
+const BaseChecker = require('../base-checker')
+const naming = require('../../common/identifier-naming')
 
 const ruleId = 'var-name-mixedcase'
 const meta = {
@@ -7,14 +7,14 @@ const meta = {
 
   docs: {
     description: `Variable name must be in mixedCase.`,
-    category: 'Style Guide Rules'
+    category: 'Style Guide Rules',
   },
 
   isDefault: false,
   recommended: true,
   defaultSetup: 'warn',
 
-  schema: null
+  schema: null,
 }
 
 class VarNameMixedcaseChecker extends BaseChecker {

--- a/lib/rules/order/func-order.js
+++ b/lib/rules/order/func-order.js
@@ -1,4 +1,4 @@
-const BaseChecker = require('./../base-checker')
+const BaseChecker = require('../base-checker')
 const { isFallbackFunction } = require('../../common/ast-types')
 
 const ruleId = 'func-order'
@@ -12,16 +12,16 @@ const meta = {
       good: [
         {
           description: 'Constructor is placed before other functions',
-          code: require('../../../test/fixtures/order/func-order-constructor-first')
-        }
+          code: require('../../../test/fixtures/order/func-order-constructor-first'),
+        },
       ],
       bad: [
         {
           description: 'Constructor is placed after other functions',
-          code: require('../../../test/fixtures/order/func-order-constructor-not-first')
-        }
-      ]
-    }
+          code: require('../../../test/fixtures/order/func-order-constructor-not-first'),
+        },
+      ],
+    },
   },
 
   isDefault: false,
@@ -30,7 +30,7 @@ const meta = {
   recommended: false,
   defaultSetup: 'warn',
 
-  schema: null
+  schema: null,
 }
 
 class FuncOrderChecker extends BaseChecker {
@@ -62,9 +62,7 @@ class FuncOrderChecker extends BaseChecker {
   }
 
   report(node, nodeBefore, label, labelBefore) {
-    const message = `Function order is incorrect, ${label} can not go after ${labelBefore} (line ${
-      nodeBefore.loc.start.line
-    })`
+    const message = `Function order is incorrect, ${label} can not go after ${labelBefore} (line ${nodeBefore.loc.start.line})`
     this.reporter.error(node, this.ruleId, message)
   }
 }

--- a/lib/rules/order/imports-on-top.js
+++ b/lib/rules/order/imports-on-top.js
@@ -1,4 +1,4 @@
-const BaseChecker = require('./../base-checker')
+const BaseChecker = require('../base-checker')
 
 const ruleId = 'imports-on-top'
 const meta = {
@@ -6,14 +6,14 @@ const meta = {
 
   docs: {
     description: `Import statements must be on top.`,
-    category: 'Style Guide Rules'
+    category: 'Style Guide Rules',
   },
 
   isDefault: false,
   recommended: true,
   defaultSetup: 'warn',
 
-  schema: null
+  schema: null,
 }
 
 class ImportsOnTopChecker extends BaseChecker {

--- a/lib/rules/order/index.js
+++ b/lib/rules/order/index.js
@@ -8,6 +8,6 @@ module.exports = function order(reporter, tokens) {
     new FuncOrderChecker(reporter),
     new ImportsOnTopChecker(reporter),
     new VisibilityModifierOrderChecker(reporter, tokens),
-    new OrderingChecker(reporter)
+    new OrderingChecker(reporter),
   ]
 }

--- a/lib/rules/order/ordering.js
+++ b/lib/rules/order/ordering.js
@@ -1,4 +1,4 @@
-const BaseChecker = require('./../base-checker')
+const BaseChecker = require('../base-checker')
 const { isFallbackFunction, isReceiveFunction } = require('../../common/ast-types')
 
 const ruleId = 'ordering'
@@ -10,15 +10,15 @@ const meta = {
     category: 'Style Guide Rules',
     examples: {
       good: require('../../../test/fixtures/order/ordering-correct'),
-      bad: require('../../../test/fixtures/order/ordering-incorrect')
-    }
+      bad: require('../../../test/fixtures/order/ordering-incorrect'),
+    },
   },
 
   isDefault: false,
   recommended: false,
   defaultSetup: 'warn',
 
-  schema: null
+  schema: null,
 }
 
 class OrderingChecker extends BaseChecker {
@@ -60,9 +60,7 @@ class OrderingChecker extends BaseChecker {
   }
 
   report(node, nodeBefore, label, labelBefore) {
-    const message = `Function order is incorrect, ${label} can not go after ${labelBefore} (line ${
-      nodeBefore.loc.start.line
-    })`
+    const message = `Function order is incorrect, ${label} can not go after ${labelBefore} (line ${nodeBefore.loc.start.line})`
     this.reporter.error(node, this.ruleId, message)
   }
 }

--- a/lib/rules/order/visibility-modifier-order.js
+++ b/lib/rules/order/visibility-modifier-order.js
@@ -1,4 +1,4 @@
-const BaseChecker = require('./../base-checker')
+const BaseChecker = require('../base-checker')
 
 const ruleId = 'visibility-modifier-order'
 const meta = {
@@ -11,23 +11,23 @@ const meta = {
       good: [
         {
           description: 'Visibility modifier placed first',
-          code: require('../../../test/fixtures/order/visibility-modifier-first')
-        }
+          code: require('../../../test/fixtures/order/visibility-modifier-first'),
+        },
       ],
       bad: [
         {
           description: 'Visibility modifier not placed first',
-          code: require('../../../test/fixtures/order/visibility-modifier-not-first')
-        }
-      ]
-    }
+          code: require('../../../test/fixtures/order/visibility-modifier-not-first'),
+        },
+      ],
+    },
   },
 
   isDefault: false,
   recommended: true,
   defaultSetup: 'warn',
 
-  schema: null
+  schema: null,
 }
 
 class VisibilityModifierOrderChecker extends BaseChecker {
@@ -42,7 +42,7 @@ class VisibilityModifierOrderChecker extends BaseChecker {
       ? node.parameters[parametersCount - 1].loc.end
       : node.loc.start
     const lastParamIndex = this.tokens.findIndex(
-      token =>
+      (token) =>
         token.loc.start.line === nodeStart.line && token.loc.start.column === nodeStart.column
     )
 
@@ -63,7 +63,7 @@ class VisibilityModifierOrderChecker extends BaseChecker {
 
         const {
           type,
-          loc: { start }
+          loc: { start },
         } = token
 
         if (start.line <= nodeEnd.line && ['Keyword', 'Identifier'].includes(type)) {
@@ -71,10 +71,10 @@ class VisibilityModifierOrderChecker extends BaseChecker {
         }
       }
 
-      const visibilityIndex = functionTokens.findIndex(t => t.value === node.visibility)
-      const stateMutabilityIndex = functionTokens.findIndex(t => t.value === node.stateMutability)
+      const visibilityIndex = functionTokens.findIndex((t) => t.value === node.visibility)
+      const stateMutabilityIndex = functionTokens.findIndex((t) => t.value === node.stateMutability)
       const modifierIndex = node.modifiers.length
-        ? functionTokens.findIndex(t => t.value === node.modifiers[0].name)
+        ? functionTokens.findIndex((t) => t.value === node.modifiers[0].name)
         : -1
 
       if (

--- a/lib/rules/security/avoid-call-value.js
+++ b/lib/rules/security/avoid-call-value.js
@@ -1,4 +1,4 @@
-const BaseChecker = require('./../base-checker')
+const BaseChecker = require('../base-checker')
 
 const ruleId = 'avoid-call-value'
 const meta = {
@@ -6,14 +6,14 @@ const meta = {
 
   docs: {
     description: `Avoid to use ".call.value()()".`,
-    category: 'Security Rules'
+    category: 'Security Rules',
   },
 
   isDefault: false,
   recommended: true,
   defaultSetup: 'warn',
 
-  schema: null
+  schema: null,
 }
 
 class AvoidCallValueChecker extends BaseChecker {

--- a/lib/rules/security/avoid-low-level-calls.js
+++ b/lib/rules/security/avoid-low-level-calls.js
@@ -1,5 +1,5 @@
-const BaseChecker = require('./../base-checker')
-const { hasMethodCalls } = require('./../../common/tree-traversing')
+const BaseChecker = require('../base-checker')
+const { hasMethodCalls } = require('../../common/tree-traversing')
 
 const ruleId = 'avoid-low-level-calls'
 const meta = {
@@ -12,17 +12,17 @@ const meta = {
       bad: [
         {
           description: 'Using low level calls',
-          code: require('../../../test/fixtures/security/low-level-calls').join('\n')
-        }
-      ]
-    }
+          code: require('../../../test/fixtures/security/low-level-calls').join('\n'),
+        },
+      ],
+    },
   },
 
   isDefault: false,
   recommended: true,
   defaultSetup: 'warn',
 
-  schema: null
+  schema: null,
 }
 
 class AvoidLowLevelCallsChecker extends BaseChecker {

--- a/lib/rules/security/avoid-sha3.js
+++ b/lib/rules/security/avoid-sha3.js
@@ -1,4 +1,4 @@
-const BaseChecker = require('./../base-checker')
+const BaseChecker = require('../base-checker')
 
 const ruleId = 'avoid-sha3'
 const meta = {
@@ -6,7 +6,7 @@ const meta = {
 
   docs: {
     description: `Use "keccak256" instead of deprecated "sha3".`,
-    category: 'Security Rules'
+    category: 'Security Rules',
   },
 
   isDefault: false,
@@ -14,7 +14,7 @@ const meta = {
   defaultSetup: 'warn',
   fixable: true,
 
-  schema: null
+  schema: null,
 }
 
 class AvoidSha3Checker extends BaseChecker {
@@ -24,7 +24,7 @@ class AvoidSha3Checker extends BaseChecker {
 
   Identifier(node) {
     if (node.name === 'sha3') {
-      this.error(node, 'Use "keccak256" instead of deprecated "sha3"', fixer =>
+      this.error(node, 'Use "keccak256" instead of deprecated "sha3"', (fixer) =>
         fixer.replaceTextRange(node.range, 'keccak256')
       )
     }

--- a/lib/rules/security/avoid-suicide.js
+++ b/lib/rules/security/avoid-suicide.js
@@ -1,4 +1,4 @@
-const BaseChecker = require('./../base-checker')
+const BaseChecker = require('../base-checker')
 
 const ruleId = 'avoid-suicide'
 const meta = {
@@ -6,14 +6,14 @@ const meta = {
 
   docs: {
     description: `Use "selfdestruct" instead of deprecated "suicide".`,
-    category: 'Security Rules'
+    category: 'Security Rules',
   },
 
   isDefault: false,
   recommended: true,
   defaultSetup: 'warn',
 
-  schema: null
+  schema: null,
 }
 
 class AvoidSuicideChecker extends BaseChecker {

--- a/lib/rules/security/avoid-throw.js
+++ b/lib/rules/security/avoid-throw.js
@@ -1,4 +1,4 @@
-const BaseChecker = require('./../base-checker')
+const BaseChecker = require('../base-checker')
 
 const ruleId = 'avoid-throw'
 const meta = {
@@ -6,7 +6,7 @@ const meta = {
 
   docs: {
     description: `"throw" is deprecated, avoid to use it.`,
-    category: 'Security Rules'
+    category: 'Security Rules',
   },
 
   isDefault: false,
@@ -14,7 +14,7 @@ const meta = {
   defaultSetup: 'warn',
   fixable: true,
 
-  schema: null
+  schema: null,
 }
 
 class AvoidThrowChecker extends BaseChecker {
@@ -23,7 +23,7 @@ class AvoidThrowChecker extends BaseChecker {
   }
 
   ThrowStatement(node) {
-    this.error(node, '"throw" is deprecated, avoid to use it', fixer =>
+    this.error(node, '"throw" is deprecated, avoid to use it', (fixer) =>
       // we don't use just `node.range` because ThrowStatement includes the semicolon and the spaces before it
       // we know that node.range[0] is the 't' of throw
       // we're also pretty sure that 'throw' has 5 letters

--- a/lib/rules/security/avoid-tx-origin.js
+++ b/lib/rules/security/avoid-tx-origin.js
@@ -1,4 +1,4 @@
-const BaseChecker = require('./../base-checker')
+const BaseChecker = require('../base-checker')
 
 const ruleId = 'avoid-tx-origin'
 const meta = {
@@ -6,14 +6,14 @@ const meta = {
 
   docs: {
     description: `Avoid to use tx.origin.`,
-    category: 'Security Rules'
+    category: 'Security Rules',
   },
 
   isDefault: false,
   recommended: true,
   defaultSetup: 'warn',
 
-  schema: null
+  schema: null,
 }
 
 class AvoidTxOriginChecker extends BaseChecker {

--- a/lib/rules/security/check-send-result.js
+++ b/lib/rules/security/check-send-result.js
@@ -1,5 +1,5 @@
-const BaseChecker = require('./../base-checker')
-const TreeTraversing = require('./../../common/tree-traversing')
+const BaseChecker = require('../base-checker')
+const TreeTraversing = require('../../common/tree-traversing')
 
 const traversing = new TreeTraversing()
 
@@ -14,23 +14,23 @@ const meta = {
       good: [
         {
           description: 'result of "send" call checked with if statement',
-          code: require('../../../test/fixtures/security/send-result-checked')
-        }
+          code: require('../../../test/fixtures/security/send-result-checked'),
+        },
       ],
       bad: [
         {
           description: 'result of "send" call ignored',
-          code: require('../../../test/fixtures/security/send-result-ignored')
-        }
-      ]
-    }
+          code: require('../../../test/fixtures/security/send-result-ignored'),
+        },
+      ],
+    },
   },
 
   isDefault: false,
   recommended: true,
   defaultSetup: 'warn',
 
-  schema: null
+  schema: null,
 }
 
 class CheckSendResultChecker extends BaseChecker {

--- a/lib/rules/security/compiler-version.js
+++ b/lib/rules/security/compiler-version.js
@@ -1,5 +1,5 @@
 const semver = require('semver')
-const BaseChecker = require('./../base-checker')
+const BaseChecker = require('../base-checker')
 const { severityDescription } = require('../../doc/utils')
 
 const ruleId = 'compiler-version'
@@ -14,13 +14,13 @@ const meta = {
     options: [
       {
         description: severityDescription,
-        default: DEFAULT_SEVERITY
+        default: DEFAULT_SEVERITY,
       },
       {
         description: `Semver requirement`,
-        default: DEFAULT_SEMVER
-      }
-    ]
+        default: DEFAULT_SEMVER,
+      },
+    ],
   },
 
   isDefault: false,
@@ -28,8 +28,8 @@ const meta = {
   defaultSetup: [DEFAULT_SEVERITY, DEFAULT_SEMVER],
 
   schema: {
-    type: 'string'
-  }
+    type: 'string',
+  },
 }
 
 class CompilerVersionChecker extends BaseChecker {
@@ -40,7 +40,9 @@ class CompilerVersionChecker extends BaseChecker {
   }
 
   SourceUnit(node) {
-    const hasPragmaDirectiveDef = node.children.some(curItem => curItem.type === 'PragmaDirective')
+    const hasPragmaDirectiveDef = node.children.some(
+      (curItem) => curItem.type === 'PragmaDirective'
+    )
 
     if (!hasPragmaDirectiveDef) {
       this.warn(node, 'Compiler version must be declared ')

--- a/lib/rules/security/func-visibility.js
+++ b/lib/rules/security/func-visibility.js
@@ -1,4 +1,4 @@
-const BaseChecker = require('./../base-checker')
+const BaseChecker = require('../base-checker')
 const { severityDescription } = require('../../doc/utils')
 
 const DEFAULT_SEVERITY = 'warn'
@@ -15,28 +15,28 @@ const meta = {
     options: [
       {
         description: severityDescription,
-        default: DEFAULT_SEVERITY
+        default: DEFAULT_SEVERITY,
       },
       {
         description:
           'A JSON object with a single property "ignoreConstructors" specifying if the rule should ignore constructors. (**Note: This is required to be true for Solidity >=0.7.0 and false for <0.7.0**)',
-        default: JSON.stringify(DEFAULT_OPTION)
-      }
+        default: JSON.stringify(DEFAULT_OPTION),
+      },
     ],
     examples: {
       good: [
         {
           description: 'Functions explicitly marked with visibility',
-          code: require('../../../test/fixtures/security/functions-with-visibility').join('\n')
-        }
+          code: require('../../../test/fixtures/security/functions-with-visibility').join('\n'),
+        },
       ],
       bad: [
         {
           description: 'Functions without explicitly marked visibility',
-          code: require('../../../test/fixtures/security/functions-without-visibility').join('\n')
-        }
-      ]
-    }
+          code: require('../../../test/fixtures/security/functions-without-visibility').join('\n'),
+        },
+      ],
+    },
   },
 
   isDefault: false,
@@ -47,10 +47,10 @@ const meta = {
     type: 'object',
     properties: {
       ignoreConstructors: {
-        type: 'boolean'
-      }
-    }
-  }
+        type: 'boolean',
+      },
+    },
+  },
 }
 
 class FuncVisibilityChecker extends BaseChecker {

--- a/lib/rules/security/index.js
+++ b/lib/rules/security/index.js
@@ -34,6 +34,6 @@ module.exports = function security(reporter, config, inputSrc) {
     new NotRelyOnBlockHashChecker(reporter),
     new NotRelyOnTimeChecker(reporter),
     new ReentrancyChecker(reporter, inputSrc),
-    new StateVisibilityChecker(reporter)
+    new StateVisibilityChecker(reporter),
   ]
 }

--- a/lib/rules/security/mark-callable-contracts.js
+++ b/lib/rules/security/mark-callable-contracts.js
@@ -15,13 +15,13 @@ const meta = {
       good: [
         {
           description: 'External contract name with "Trusted" prefix',
-          code: require('../../../test/fixtures/security/external-contract-trusted.js'),
+          code: require('../../../test/fixtures/security/external-contract-trusted'),
         },
       ],
       bad: [
         {
           description: 'External contract name without "Trusted" prefix',
-          code: require('../../../test/fixtures/security/external-contract-untrusted.js'),
+          code: require('../../../test/fixtures/security/external-contract-untrusted'),
         },
       ],
     },

--- a/lib/rules/security/mark-callable-contracts.js
+++ b/lib/rules/security/mark-callable-contracts.js
@@ -1,5 +1,5 @@
-const TreeTraversing = require('./../../common/tree-traversing')
-const Reporter = require('./../../reporter')
+const TreeTraversing = require('../../common/tree-traversing')
+const Reporter = require('../../reporter')
 
 const traversing = new TreeTraversing()
 const SEVERITY = Reporter.SEVERITY
@@ -15,16 +15,16 @@ const meta = {
       good: [
         {
           description: 'External contract name with "Trusted" prefix',
-          code: require('../../../test/fixtures/security/external-contract-trusted.js')
-        }
+          code: require('../../../test/fixtures/security/external-contract-trusted.js'),
+        },
       ],
       bad: [
         {
           description: 'External contract name without "Trusted" prefix',
-          code: require('../../../test/fixtures/security/external-contract-untrusted.js')
-        }
-      ]
-    }
+          code: require('../../../test/fixtures/security/external-contract-untrusted.js'),
+        },
+      ],
+    },
   },
 
   isDefault: false,
@@ -32,7 +32,7 @@ const meta = {
   defaultSetup: 'warn',
   deprecated: true,
 
-  schema: null
+  schema: null,
 }
 
 class MarkCallableContractsChecker {

--- a/lib/rules/security/multiple-sends.js
+++ b/lib/rules/security/multiple-sends.js
@@ -1,5 +1,5 @@
-const BaseChecker = require('./../base-checker')
-const TreeTraversing = require('./../../common/tree-traversing')
+const BaseChecker = require('../base-checker')
+const TreeTraversing = require('../../common/tree-traversing')
 
 const traversing = new TreeTraversing()
 
@@ -9,14 +9,14 @@ const meta = {
 
   docs: {
     description: `Avoid multiple calls of "send" method in single transaction.`,
-    category: 'Security Rules'
+    category: 'Security Rules',
   },
 
   isDefault: false,
   recommended: true,
   defaultSetup: 'warn',
 
-  schema: null
+  schema: null,
 }
 
 class MultipleSendsChecker extends BaseChecker {

--- a/lib/rules/security/no-complex-fallback.js
+++ b/lib/rules/security/no-complex-fallback.js
@@ -1,4 +1,4 @@
-const BaseChecker = require('./../base-checker')
+const BaseChecker = require('../base-checker')
 const { isFallbackFunction } = require('../../common/ast-types')
 
 const ruleId = 'no-complex-fallback'
@@ -7,14 +7,14 @@ const meta = {
 
   docs: {
     description: `Fallback function must be simple.`,
-    category: 'Security Rules'
+    category: 'Security Rules',
   },
 
   isDefault: false,
   recommended: true,
   defaultSetup: 'warn',
 
-  schema: null
+  schema: null,
 }
 
 class NoComplexFallbackChecker extends BaseChecker {

--- a/lib/rules/security/no-inline-assembly.js
+++ b/lib/rules/security/no-inline-assembly.js
@@ -1,4 +1,4 @@
-const BaseChecker = require('./../base-checker')
+const BaseChecker = require('../base-checker')
 
 const ruleId = 'no-inline-assembly'
 const meta = {
@@ -6,14 +6,14 @@ const meta = {
 
   docs: {
     description: `Avoid to use inline assembly. It is acceptable only in rare cases.`,
-    category: 'Security Rules'
+    category: 'Security Rules',
   },
 
   isDefault: false,
   recommended: true,
   defaultSetup: 'warn',
 
-  schema: null
+  schema: null,
 }
 
 class NoInlineAssemblyChecker extends BaseChecker {

--- a/lib/rules/security/not-rely-on-block-hash.js
+++ b/lib/rules/security/not-rely-on-block-hash.js
@@ -1,4 +1,4 @@
-const BaseChecker = require('./../base-checker')
+const BaseChecker = require('../base-checker')
 
 const ruleId = 'not-rely-on-block-hash'
 const meta = {
@@ -6,14 +6,14 @@ const meta = {
 
   docs: {
     description: `Do not rely on "block.blockhash". Miners can influence its value.`,
-    category: 'Security Rules'
+    category: 'Security Rules',
   },
 
   isDefault: false,
   recommended: true,
   defaultSetup: 'warn',
 
-  schema: null
+  schema: null,
 }
 
 class NotRelyOnBlockHashChecker extends BaseChecker {

--- a/lib/rules/security/not-rely-on-time.js
+++ b/lib/rules/security/not-rely-on-time.js
@@ -1,4 +1,4 @@
-const BaseChecker = require('./../base-checker')
+const BaseChecker = require('../base-checker')
 
 const ruleId = 'not-rely-on-time'
 const meta = {
@@ -6,14 +6,14 @@ const meta = {
 
   docs: {
     description: `Avoid making time-based decisions in your business logic.`,
-    category: 'Security Rules'
+    category: 'Security Rules',
   },
 
   isDefault: false,
   recommended: true,
   defaultSetup: 'warn',
 
-  schema: null
+  schema: null,
 }
 
 class NotRelyOnTimeChecker extends BaseChecker {

--- a/lib/rules/security/reentrancy.js
+++ b/lib/rules/security/reentrancy.js
@@ -1,6 +1,6 @@
 const _ = require('lodash')
-const BaseChecker = require('./../base-checker')
-const TreeTraversing = require('./../../common/tree-traversing')
+const BaseChecker = require('../base-checker')
+const TreeTraversing = require('../../common/tree-traversing')
 
 const { hasMethodCalls, findPropertyInParents } = TreeTraversing
 
@@ -15,35 +15,35 @@ const meta = {
       good: [
         {
           description: 'Invulnerable Contract 1',
-          code: require('../../../test/fixtures/security/reentrancy-invulenarble')[0]
+          code: require('../../../test/fixtures/security/reentrancy-invulenarble')[0],
         },
         {
           description: 'Invulnerable Contract 2',
-          code: require('../../../test/fixtures/security/reentrancy-invulenarble')[1]
+          code: require('../../../test/fixtures/security/reentrancy-invulenarble')[1],
         },
         {
           description: 'Invulnerable Contract 3',
-          code: require('../../../test/fixtures/security/reentrancy-invulenarble')[2]
-        }
+          code: require('../../../test/fixtures/security/reentrancy-invulenarble')[2],
+        },
       ],
       bad: [
         {
           description: 'Vulnerable Contract 1',
-          code: require('../../../test/fixtures/security/reentrancy-vulenarble')[0]
+          code: require('../../../test/fixtures/security/reentrancy-vulenarble')[0],
         },
         {
           description: 'Vulnerable Contract 2',
-          code: require('../../../test/fixtures/security/reentrancy-vulenarble')[1]
-        }
-      ]
-    }
+          code: require('../../../test/fixtures/security/reentrancy-vulenarble')[1],
+        },
+      ],
+    },
   },
 
   isDefault: false,
   recommended: true,
   defaultSetup: 'warn',
 
-  schema: null
+  schema: null,
 }
 
 class ReentrancyChecker extends BaseChecker {
@@ -56,7 +56,7 @@ class ReentrancyChecker extends BaseChecker {
     node.stateDeclarationScope = new StateDeclarationScope()
     const scope = node.stateDeclarationScope
 
-    new ContractDefinition(node).stateDefinitions().forEach(i => scope.trackStateDeclaration(i))
+    new ContractDefinition(node).stateDefinitions().forEach((i) => scope.trackStateDeclaration(i))
   }
 
   FunctionDefinition(node) {
@@ -132,9 +132,9 @@ class ContractDefinition {
 
   stateDefinitions() {
     return this.node.subNodes
-      .map(i => new ContractPart(i))
-      .filter(i => i.isStateDefinition())
-      .map(i => i.getStateDefinition())
+      .map((i) => new ContractPart(i))
+      .filter((i) => i.isStateDefinition())
+      .map((i) => i.getStateDefinition())
   }
 }
 
@@ -181,7 +181,7 @@ class AssignOperator {
   modifyOneOf(states) {
     const assigneeText = this._assignee()
 
-    return states.some(curStateName => assigneeText.includes(curStateName))
+    return states.some((curStateName) => assigneeText.includes(curStateName))
   }
 
   _assignee() {

--- a/lib/rules/security/state-visibility.js
+++ b/lib/rules/security/state-visibility.js
@@ -1,4 +1,4 @@
-const BaseChecker = require('./../base-checker')
+const BaseChecker = require('../base-checker')
 
 const ruleId = 'state-visibility'
 const meta = {
@@ -6,14 +6,14 @@ const meta = {
 
   docs: {
     description: `Explicitly mark visibility of state.`,
-    category: 'Security Rules'
+    category: 'Security Rules',
   },
 
   isDefault: false,
   recommended: true,
   defaultSetup: 'warn',
 
-  schema: null
+  schema: null,
 }
 
 class StateVisibilityChecker extends BaseChecker {

--- a/lib/tree-listener.js
+++ b/lib/tree-listener.js
@@ -2,17 +2,17 @@ class SecurityErrorListener {
   constructor(checkers) {
     this.listenersMap = {}
 
-    checkers.forEach(i => this.addChecker(i))
+    checkers.forEach((i) => this.addChecker(i))
   }
 
   addChecker(newChecker) {
     const listenerMethods = Object.getOwnPropertyNames(newChecker.constructor.prototype)
 
-    const usedListenerMethods = listenerMethods.filter(i => /^[A-Z]/.test(i))
+    const usedListenerMethods = listenerMethods.filter((i) => /^[A-Z]/.test(i))
 
-    usedListenerMethods.forEach(methodName => this.addNewListener(methodName, newChecker))
+    usedListenerMethods.forEach((methodName) => this.addNewListener(methodName, newChecker))
 
-    usedListenerMethods.forEach(methodName => {
+    usedListenerMethods.forEach((methodName) => {
       this[methodName] = this.notifyListenersOn(methodName)
     })
   }
@@ -28,7 +28,7 @@ class SecurityErrorListener {
   }
 
   notifyListenersOn(methodName) {
-    return ctx => this.listenersFor(methodName).forEach(fn => quite(fn)(ctx))
+    return (ctx) => this.listenersFor(methodName).forEach((fn) => quite(fn)(ctx))
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,8 +21,10 @@
         "ignore": "^5.2.4",
         "js-yaml": "^4.1.0",
         "lodash": "^4.17.21",
+        "pluralize": "^8.0.0",
         "semver": "^6.3.0",
         "strip-ansi": "^6.0.1",
+        "table": "^6.8.1",
         "text-table": "^0.2.0"
       },
       "bin": {
@@ -911,6 +913,14 @@
       "resolved": "https://registry.npmjs.org/ast-parents/-/ast-parents-0.0.1.tgz",
       "integrity": "sha512-XHusKxKz3zoYk1ic8Un640joHbFMhbqneyoZfoKnEGtf2ey9Uh/IdpcQplODdO/kENaMIWsD0nJm4+wX3UNLHA=="
     },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -1423,8 +1433,7 @@
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -2658,7 +2667,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -3151,6 +3159,11 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw=="
     },
     "node_modules/log-driver": {
       "version": "1.2.7",
@@ -3955,6 +3968,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -4167,6 +4188,14 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4411,6 +4440,22 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
+    "node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -4472,7 +4517,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -4564,6 +4608,41 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/table": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.8.1.tgz",
+      "integrity": "sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==",
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/table/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/table/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",
@@ -5680,6 +5759,11 @@
       "resolved": "https://registry.npmjs.org/ast-parents/-/ast-parents-0.0.1.tgz",
       "integrity": "sha512-XHusKxKz3zoYk1ic8Un640joHbFMhbqneyoZfoKnEGtf2ey9Uh/IdpcQplODdO/kENaMIWsD0nJm4+wX3UNLHA=="
     },
+    "astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ=="
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -6061,8 +6145,7 @@
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -6966,8 +7049,7 @@
     "is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
     },
     "is-generator-function": {
       "version": "1.0.10",
@@ -7321,6 +7403,11 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw=="
     },
     "log-driver": {
       "version": "1.2.7",
@@ -7922,6 +8009,11 @@
         }
       }
     },
+    "pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="
+    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -8069,6 +8161,11 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true
+    },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
     },
     "require-main-filename": {
       "version": "2.0.0",
@@ -8234,6 +8331,16 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
+    "slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      }
+    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -8281,7 +8388,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -8343,6 +8449,36 @@
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
+    },
+    "table": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.8.1.tgz",
+      "integrity": "sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==",
+      "requires": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+          "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        }
+      }
     },
     "test-exclude": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -46,8 +46,10 @@
     "ignore": "^5.2.4",
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",
+    "pluralize": "^8.0.0",
     "semver": "^6.3.0",
     "strip-ansi": "^6.0.1",
+    "table": "^6.8.1",
     "text-table": "^0.2.0"
   },
   "devDependencies": {

--- a/solhint.js
+++ b/solhint.js
@@ -64,21 +64,22 @@ function execMainAction() {
   const reportLists = program.args.filter(_.isString).map(processPath)
   const reports = _.flatten(reportLists)
   const warningsCount = reports.reduce((acc, i) => acc + i.warningCount, 0)
-  const warningsNumberExceeded = program.opts().maxWarnings >= 0 && warningsCount > program.opts().maxWarnings
+  const warningsNumberExceeded =
+    program.opts().maxWarnings >= 0 && warningsCount > program.opts().maxWarnings
 
   if (program.opts().fix) {
     for (const report of reports) {
       const inputSrc = fs.readFileSync(report.filePath).toString()
 
       const fixes = _(report.reports)
-        .filter(x => x.fix)
-        .map(x => x.fix(ruleFixer))
+        .filter((x) => x.fix)
+        .map((x) => x.fix(ruleFixer))
         .sort((a, b) => a.range[0] - b.range[0])
         .value()
 
       const { fixed, output } = applyFixes(fixes, inputSrc)
       if (fixed) {
-        report.reports = report.reports.filter(x => !x.fix)
+        report.reports = report.reports.filter((x) => !x.fix)
         fs.writeFileSync(report.filePath, output)
       }
     }
@@ -86,7 +87,7 @@ function execMainAction() {
 
   if (program.opts().quiet) {
     // filter the list of reports, to set errors only.
-    reports[0].reports = reports[0].reports.filter(i => i.severity === 2)
+    reports[0].reports = reports[0].reports.filter((i) => i.severity === 2)
   }
 
   if (printReports(reports, formatterFn)) {
@@ -143,7 +144,7 @@ const readIgnore = _.memoize(() => {
       .readFileSync(ignoreFile)
       .toString()
       .split('\n')
-      .map(i => i.trim())
+      .map((i) => i.trim())
   } catch (e) {
     if (program.opts().ignorePath && e.code === 'ENOENT') {
       console.error(`\nERROR: ${ignoreFile} is not a valid path.`)
@@ -189,9 +190,9 @@ function getFormatter(formatter) {
   try {
     return require(`./lib/formatters/${formatterName}`)
   } catch (ex) {
-    ex.message = `\nThere was a problem loading formatter option: ${program.opts().formatter} \nError: ${
-      ex.message
-    }`
+    ex.message = `\nThere was a problem loading formatter option: ${
+      program.opts().formatter
+    } \nError: ${ex.message}`
     throw ex
   }
 }

--- a/test/common/apply-extends.js
+++ b/test/common/apply-extends.js
@@ -1,12 +1,12 @@
 const assert = require('assert')
-const { applyExtends } = require('./../../lib/config/config-file')
+const { applyExtends } = require('../../lib/config/config-file')
 
 describe('applyExtends', () => {
   it('should return the same config if the extends property does not exist', () => {
     const initialConfig = {
       rules: {
-        rule0: 'error'
-      }
+        rule0: 'error',
+      },
     }
     const result = applyExtends(initialConfig)
 
@@ -17,8 +17,8 @@ describe('applyExtends', () => {
     const initialConfig = {
       extends: [],
       rules: {
-        rule0: 'error'
-      }
+        rule0: 'error',
+      },
     }
     const result = applyExtends(initialConfig)
 
@@ -29,22 +29,22 @@ describe('applyExtends', () => {
     const initialConfig = {
       extends: ['config1'],
       rules: {
-        rule0: 'error'
-      }
+        rule0: 'error',
+      },
     }
     const config1 = {
       rules: {
-        rule1: 'warning'
-      }
+        rule1: 'warning',
+      },
     }
-    const result = applyExtends(initialConfig, configName => ({ config1 }[configName]))
+    const result = applyExtends(initialConfig, (configName) => ({ config1 }[configName]))
 
     assert.deepStrictEqual(result, {
       extends: ['config1'],
       rules: {
         rule0: 'error',
-        rule1: 'warning'
-      }
+        rule1: 'warning',
+      },
     })
   })
 
@@ -52,22 +52,22 @@ describe('applyExtends', () => {
     const initialConfig = {
       extends: 'config1',
       rules: {
-        rule0: 'error'
-      }
+        rule0: 'error',
+      },
     }
     const config1 = {
       rules: {
-        rule1: 'warning'
-      }
+        rule1: 'warning',
+      },
     }
-    const result = applyExtends(initialConfig, configName => ({ config1 }[configName]))
+    const result = applyExtends(initialConfig, (configName) => ({ config1 }[configName]))
 
     assert.deepStrictEqual(result, {
       extends: ['config1'],
       rules: {
         rule0: 'error',
-        rule1: 'warning'
-      }
+        rule1: 'warning',
+      },
     })
   })
 
@@ -75,27 +75,27 @@ describe('applyExtends', () => {
     const initialConfig = {
       extends: ['config1', 'config2'],
       rules: {
-        rule0: 'error'
-      }
+        rule0: 'error',
+      },
     }
     const config1 = {
       rules: {
-        rule1: 'warning'
-      }
+        rule1: 'warning',
+      },
     }
     const config2 = {
       rules: {
-        rule1: 'off'
-      }
+        rule1: 'off',
+      },
     }
-    const result = applyExtends(initialConfig, configName => ({ config1, config2 }[configName]))
+    const result = applyExtends(initialConfig, (configName) => ({ config1, config2 }[configName]))
 
     assert.deepStrictEqual(result, {
       extends: ['config1', 'config2'],
       rules: {
         rule0: 'error',
-        rule1: 'off'
-      }
+        rule1: 'off',
+      },
     })
   })
 
@@ -103,26 +103,26 @@ describe('applyExtends', () => {
     const initialConfig = {
       extends: ['config1', 'config2'],
       rules: {
-        rule0: 'error'
-      }
+        rule0: 'error',
+      },
     }
     const config1 = {
       rules: {
-        rule0: 'warning'
-      }
+        rule0: 'warning',
+      },
     }
     const config2 = {
       rules: {
-        rule0: 'off'
-      }
+        rule0: 'off',
+      },
     }
-    const result = applyExtends(initialConfig, configName => ({ config1, config2 }[configName]))
+    const result = applyExtends(initialConfig, (configName) => ({ config1, config2 }[configName]))
 
     assert.deepStrictEqual(result, {
       extends: ['config1', 'config2'],
       rules: {
-        rule0: 'error'
-      }
+        rule0: 'error',
+      },
     })
   })
 })

--- a/test/common/apply-fixes.js
+++ b/test/common/apply-fixes.js
@@ -23,8 +23,8 @@ contract Foo {
     const fixes = [
       {
         range: [38, 42],
-        text: 'revert()'
-      }
+        text: 'revert()',
+      },
     ]
 
     const { fixed, output } = applyFixes(fixes, inputSrc)
@@ -53,12 +53,12 @@ contract Foo {
     const fixes = [
       {
         range: [38, 42],
-        text: 'revert()'
+        text: 'revert()',
       },
       {
         range: [49, 53],
-        text: 'revert()'
-      }
+        text: 'revert()',
+      },
     ]
 
     const { fixed, output } = applyFixes(fixes, inputSrc)

--- a/test/common/asserts.js
+++ b/test/common/asserts.js
@@ -58,5 +58,5 @@ module.exports = {
   assertNoErrors,
   assertErrorCount,
   assertWarnsCount,
-  assertLineNumber
+  assertLineNumber,
 }

--- a/test/common/config-file.js
+++ b/test/common/config-file.js
@@ -1,5 +1,5 @@
 const assert = require('assert')
-const { loadConfig } = require('./../../lib/config/config-file')
+const { loadConfig } = require('../../lib/config/config-file')
 
 describe('Config file', () => {
   it(`should throw an error if the config file doesn't exist`, () => {
@@ -13,7 +13,7 @@ describe('Config file', () => {
     const loadedConfig = loadConfig('./test/helpers/solhint_config_test.json')
 
     const loadedConfigFileExpected = {
-      extends: ['solhint:recommended']
+      extends: ['solhint:recommended'],
     }
 
     assert.deepStrictEqual(loadedConfig, loadedConfigFileExpected)

--- a/test/common/config-validator.js
+++ b/test/common/config-validator.js
@@ -3,8 +3,8 @@ const _ = require('lodash')
 const {
   validate,
   validSeverityMap,
-  defaultSchemaValueForRules
-} = require('./../../lib/config/config-validator')
+  defaultSchemaValueForRules,
+} = require('../../lib/config/config-validator')
 
 describe('Config validator', () => {
   it('should check validSeverityMap', () => {
@@ -13,7 +13,7 @@ describe('Config validator', () => {
 
   it('should check defaultSchemaValueForRules', () => {
     assert.deepStrictEqual(defaultSchemaValueForRules, {
-      oneOf: [{ type: 'string', enum: ['error', 'warn', 'off'] }, { const: false }]
+      oneOf: [{ type: 'string', enum: ['error', 'warn', 'off'] }, { const: false }],
     })
   })
 
@@ -22,8 +22,8 @@ describe('Config validator', () => {
       extends: [],
       rules: {
         'avoid-throw': 'off',
-        indent: ['error', 2]
-      }
+        indent: ['error', 2],
+      },
     }
     assert.deepStrictEqual(_.isUndefined(validate(config)), true)
   })
@@ -33,8 +33,8 @@ describe('Config validator', () => {
       test: [],
       rules: {
         'avoid-throw': 'off',
-        indent: ['error', 2]
-      }
+        indent: ['error', 2],
+      },
     }
     assert.throws(() => validate(config), Error)
   })

--- a/test/common/contract-builder.js
+++ b/test/common/contract-builder.js
@@ -74,5 +74,5 @@ module.exports = {
   contractWithPrettier,
   stateDef,
   constantDef,
-  repeatLines
+  repeatLines,
 }

--- a/test/common/errors.js
+++ b/test/common/errors.js
@@ -1,5 +1,5 @@
 const assert = require('assert')
-const { ConfigMissingError } = require('./../../lib/common/errors')
+const { ConfigMissingError } = require('../../lib/common/errors')
 
 describe('errors', () => {
   it('should throw a ConfigMissingError and match the message', () => {

--- a/test/common/load-rules.js
+++ b/test/common/load-rules.js
@@ -1,6 +1,6 @@
 const assert = require('assert')
 const _ = require('lodash')
-const { loadRule, loadRules } = require('./../../lib/load-rules')
+const { loadRule, loadRules } = require('../../lib/load-rules')
 
 describe('Load Rules', () => {
   it('should load all rules', () => {

--- a/test/fixtures/align/array_declaration.js
+++ b/test/fixtures/align/array_declaration.js
@@ -1,3 +1,3 @@
-const { contractWith } = require('./../../common/contract-builder')
+const { contractWith } = require('../../common/contract-builder')
 
 module.exports = contractWith('uint[][] private a;')

--- a/test/fixtures/align/array_declaration_with_spaces.js
+++ b/test/fixtures/align/array_declaration_with_spaces.js
@@ -1,3 +1,3 @@
-const { contractWith } = require('./../../common/contract-builder')
+const { contractWith } = require('../../common/contract-builder')
 
 module.exports = contractWith('uint [] [] private a;')

--- a/test/fixtures/align/correctly_aligned_function_brackets.js
+++ b/test/fixtures/align/correctly_aligned_function_brackets.js
@@ -1,4 +1,4 @@
-const { contractWith } = require('./../../common/contract-builder')
+const { contractWith } = require('../../common/contract-builder')
 
 module.exports = contractWith(`
                 function a (

--- a/test/fixtures/align/correctly_indented_contract.js
+++ b/test/fixtures/align/correctly_indented_contract.js
@@ -1,4 +1,4 @@
-const { multiLine } = require('./../../common/contract-builder')
+const { multiLine } = require('../../common/contract-builder')
 
 module.exports = multiLine(
   'contract A {                                       ',

--- a/test/fixtures/align/expressions_with_correct_comma_align.js
+++ b/test/fixtures/align/expressions_with_correct_comma_align.js
@@ -1,9 +1,9 @@
-const { funcWith, contractWith } = require('./../../common/contract-builder')
+const { funcWith, contractWith } = require('../../common/contract-builder')
 
 module.exports = [
   funcWith('var (a, b,) = test1.test2(); a + b;'),
   funcWith('test(1, 2, b);'),
   contractWith('function b(uint a, uintc) public {}'),
   contractWith('enum A {Test1, Test2}'),
-  funcWith('var (a, , , b) = test1.test2(); a + b;')
+  funcWith('var (a, , , b) = test1.test2(); a + b;'),
 ]

--- a/test/fixtures/align/expressions_with_correct_indents.js
+++ b/test/fixtures/align/expressions_with_correct_indents.js
@@ -15,5 +15,5 @@ module.exports = [
   'a++',
   'a += 1',
   'a += (b + c) * d',
-  'bytesStringTrimmed[j] = bytesString[j]'
+  'bytesStringTrimmed[j] = bytesString[j]',
 ]

--- a/test/fixtures/align/expressions_with_incorrect_comma_align.js
+++ b/test/fixtures/align/expressions_with_incorrect_comma_align.js
@@ -1,4 +1,4 @@
-const { funcWith, contractWith } = require('./../../common/contract-builder')
+const { funcWith, contractWith } = require('../../common/contract-builder')
 
 module.exports = [
   funcWith('var (a,b) = test1.test2(); a + b;'),
@@ -6,5 +6,5 @@ module.exports = [
   funcWith('test(1,/* test */ 2, b);'),
   contractWith('function b(uint a,uintc) public {}'),
   funcWith('test(1, 2 , b);'),
-  funcWith('var (a, ,, b) = test1.test2(); a + b;')
+  funcWith('var (a, ,, b) = test1.test2(); a + b;'),
 ]

--- a/test/fixtures/align/expressions_with_incorrect_indents.js
+++ b/test/fixtures/align/expressions_with_incorrect_indents.js
@@ -13,5 +13,5 @@ module.exports = [
   'a > b ?a : b',
   '! a',
   'a ++',
-  'a +=1'
+  'a +=1',
 ]

--- a/test/fixtures/align/expressions_with_incorrect_semicolon_align.js
+++ b/test/fixtures/align/expressions_with_incorrect_semicolon_align.js
@@ -4,5 +4,5 @@ module.exports = [
   'test(1, 2, b)/* test */;',
   'for ( ;;) {}',
   'for (i = 0; ;) {}',
-  'for ( ; a < b;) {}'
+  'for ( ; a < b;) {}',
 ]

--- a/test/fixtures/align/incorrectly_aligned_forloop_brackets.js
+++ b/test/fixtures/align/incorrectly_aligned_forloop_brackets.js
@@ -1,4 +1,4 @@
-const { funcWith } = require('./../../common/contract-builder')
+const { funcWith } = require('../../common/contract-builder')
 
 module.exports = funcWith(`
     for (uint i = 0; i < a; i += 1) 

--- a/test/fixtures/align/incorrectly_aligned_function_brackets.js
+++ b/test/fixtures/align/incorrectly_aligned_function_brackets.js
@@ -1,4 +1,4 @@
-const { contractWith } = require('./../../common/contract-builder')
+const { contractWith } = require('../../common/contract-builder')
 
 module.exports = contractWith(`
                 function a (uint a) public{

--- a/test/fixtures/align/incorrectly_indented_contract.js
+++ b/test/fixtures/align/incorrectly_indented_contract.js
@@ -1,4 +1,4 @@
-const { multiLine } = require('./../../common/contract-builder')
+const { multiLine } = require('../../common/contract-builder')
 
 module.exports = multiLine(
   '    contract A {        ',

--- a/test/fixtures/align/statements_with_correct_indents.js
+++ b/test/fixtures/align/statements_with_correct_indents.js
@@ -1,4 +1,4 @@
-const { multiLine } = require('./../../common/contract-builder')
+const { multiLine } = require('../../common/contract-builder')
 
 module.exports = [
   'if (a > b) {}',
@@ -14,5 +14,5 @@ module.exports = [
   'for (; a < b; i += 1) {}',
   'for (uint i = 0; a < b; i += 1) {}',
   multiLine('if (a < b) { ', '  test1();   ', '} else {     ', '  test2();   ', '}            '),
-  multiLine('do {             ', '  test1();       ', '} while (a < b); ')
+  multiLine('do {             ', '  test1();       ', '} while (a < b); '),
 ]

--- a/test/fixtures/align/statements_with_incorrect_indents.js
+++ b/test/fixtures/align/statements_with_incorrect_indents.js
@@ -1,4 +1,4 @@
-const { multiLine } = require('./../../common/contract-builder')
+const { multiLine } = require('../../common/contract-builder')
 
 module.exports = [
   'if(a > b) {}',
@@ -21,5 +21,5 @@ module.exports = [
     '  test2();   ',
     '}            '
   ),
-  multiLine('do {           ', '  test1();     ', '}              ', 'while (a < b); ')
+  multiLine('do {           ', '  test1();     ', '}              ', 'while (a < b); '),
 ]

--- a/test/fixtures/best-practises/code-complexity-high.js
+++ b/test/fixtures/best-practises/code-complexity-high.js
@@ -1,4 +1,4 @@
-const { multiLine } = require('./../../common/contract-builder')
+const { multiLine } = require('../../common/contract-builder')
 
 module.exports = multiLine(
   ' if (a > b) {                   ',

--- a/test/fixtures/best-practises/code-complexity-low.js
+++ b/test/fixtures/best-practises/code-complexity-low.js
@@ -1,4 +1,4 @@
-const { multiLine } = require('./../../common/contract-builder')
+const { multiLine } = require('../../common/contract-builder')
 
 module.exports = multiLine(
   ' if (a > b) {                   ',

--- a/test/fixtures/best-practises/fallback-not-payable.js
+++ b/test/fixtures/best-practises/fallback-not-payable.js
@@ -1,3 +1,3 @@
-const { contractWith } = require('./../../common/contract-builder')
+const { contractWith } = require('../../common/contract-builder')
 
 module.exports = contractWith('function () public {}')

--- a/test/fixtures/best-practises/fallback-payable.js
+++ b/test/fixtures/best-practises/fallback-payable.js
@@ -1,3 +1,3 @@
-const { contractWith } = require('./../../common/contract-builder')
+const { contractWith } = require('../../common/contract-builder')
 
 module.exports = contractWith('function () public payable {}')

--- a/test/fixtures/best-practises/number-of-states-high.js
+++ b/test/fixtures/best-practises/number-of-states-high.js
@@ -1,3 +1,3 @@
-const { contractWith, stateDef } = require('./../../common/contract-builder')
+const { contractWith, stateDef } = require('../../common/contract-builder')
 
 module.exports = contractWith(stateDef(16))

--- a/test/fixtures/best-practises/number-of-states-low.js
+++ b/test/fixtures/best-practises/number-of-states-low.js
@@ -1,3 +1,3 @@
-const { contractWith, stateDef, constantDef } = require('./../../common/contract-builder')
+const { contractWith, stateDef, constantDef } = require('../../common/contract-builder')
 
 module.exports = contractWith([stateDef(10), constantDef(10)].join('\n'))

--- a/test/fixtures/best-practises/require-with-reason.js
+++ b/test/fixtures/best-practises/require-with-reason.js
@@ -1,4 +1,4 @@
-const { funcWith } = require('./../../common/contract-builder')
+const { funcWith } = require('../../common/contract-builder')
 
 module.exports = funcWith(`require(!has(role, account), "Roles: account already has role");
           role.bearer[account] = true;

--- a/test/fixtures/best-practises/require-without-reason.js
+++ b/test/fixtures/best-practises/require-without-reason.js
@@ -1,4 +1,4 @@
-const { funcWith } = require('./../../common/contract-builder')
+const { funcWith } = require('../../common/contract-builder')
 
 module.exports = funcWith(`require(!has(role, account));
           role.bearer[account] = true;

--- a/test/fixtures/miscellaneous/string-with-double-quotes.js
+++ b/test/fixtures/miscellaneous/string-with-double-quotes.js
@@ -1,3 +1,3 @@
-const { contractWith } = require('./../../common/contract-builder')
+const { contractWith } = require('../../common/contract-builder')
 
 module.exports = contractWith('string private a = "test";')

--- a/test/fixtures/miscellaneous/string-with-single-quotes.js
+++ b/test/fixtures/miscellaneous/string-with-single-quotes.js
@@ -1,3 +1,3 @@
-const { contractWith } = require('./../../common/contract-builder')
+const { contractWith } = require('../../common/contract-builder')
 
 module.exports = contractWith("string private a = 'test';")

--- a/test/fixtures/order/func-order-constructor-first.js
+++ b/test/fixtures/order/func-order-constructor-first.js
@@ -1,4 +1,4 @@
-const { contractWith } = require('./../../common/contract-builder')
+const { contractWith } = require('../../common/contract-builder')
 
 module.exports = contractWith(`
                 constructor() public {}

--- a/test/fixtures/order/func-order-constructor-not-first.js
+++ b/test/fixtures/order/func-order-constructor-not-first.js
@@ -1,4 +1,4 @@
-const { contractWith } = require('./../../common/contract-builder')
+const { contractWith } = require('../../common/contract-builder')
 
 module.exports = contractWith(`
                 function () public payable {}

--- a/test/fixtures/order/ordering-correct.js
+++ b/test/fixtures/order/ordering-correct.js
@@ -55,7 +55,7 @@ contract MyContract {
   function myInternalFunction() internal {}
   function myPrivateFunction() private {}
 }
-`
+`,
   },
   {
     description: 'All units are in order - ^0.5.0',
@@ -131,7 +131,7 @@ contract MyContract {
   function myPrivateViewFunction() private view {}
   function myPrivatePureFunction() private pure {}
 }
-`
+`,
   },
   {
     description: 'All units are in order - ^0.6.0',
@@ -209,6 +209,6 @@ contract MyContract {
   function myPrivateViewFunction() private view {}
   function myPrivatePureFunction() private pure {}
 }
-`
-  }
+`,
+  },
 ]

--- a/test/fixtures/order/ordering-incorrect.js
+++ b/test/fixtures/order/ordering-incorrect.js
@@ -7,7 +7,7 @@ module.exports = [
 
     uint a;
   }
-`
+`,
   },
   {
     description: 'Library after contract',
@@ -15,7 +15,7 @@ module.exports = [
   contract MyContract {}
 
   library MyLibrary {}
-`
+`,
   },
   {
     description: 'Interface after library',
@@ -23,7 +23,7 @@ module.exports = [
   library MyLibrary {}
 
   interface MyInterface {}
-`
+`,
   },
   {
     description: 'Use for after state variable',
@@ -33,7 +33,7 @@ contract MyContract {
   
   using MyMathLib for uint;
 }
-`
+`,
   },
   {
     description: 'External pure before external view',
@@ -43,7 +43,7 @@ contract MyContract {
   function myExternalPureFunction() external pure {}
   function myExternalViewFunction() external view {}
 }
-`
+`,
   },
   {
     description: 'Public pure before public view',
@@ -53,7 +53,7 @@ contract MyContract {
   function myPublicPureFunction() public pure {}
   function myPublicViewFunction() public view {}
 }
-`
+`,
   },
   {
     description: 'Internal pure before internal view',
@@ -63,7 +63,7 @@ contract MyContract {
   function myInternalPureFunction() internal pure {}
   function myInternalViewFunction() internal view {}
 }
-`
+`,
   },
   {
     description: 'Private pure before private view',
@@ -73,6 +73,6 @@ contract MyContract {
   function myPrivatePureFunction() private pure {}
   function myPrivateViewFunction() private view {}
 }
-`
-  }
+`,
+  },
 ]

--- a/test/fixtures/order/visibility-modifier-first.js
+++ b/test/fixtures/order/visibility-modifier-first.js
@@ -1,3 +1,3 @@
-const { contractWith } = require('./../../common/contract-builder')
+const { contractWith } = require('../../common/contract-builder')
 
 module.exports = contractWith('function a() public ownable() payable {}')

--- a/test/fixtures/order/visibility-modifier-not-first.js
+++ b/test/fixtures/order/visibility-modifier-not-first.js
@@ -1,3 +1,3 @@
-const { contractWith } = require('./../../common/contract-builder')
+const { contractWith } = require('../../common/contract-builder')
 
 module.exports = contractWith('function a() ownable() public payable {}')

--- a/test/fixtures/security/functions-with-visibility.js
+++ b/test/fixtures/security/functions-with-visibility.js
@@ -3,5 +3,5 @@ module.exports = [
   'function b() external { }',
   'function b() private { }',
   'function b() public { }',
-  'constructor() public { }'
+  'constructor() public { }',
 ]

--- a/test/fixtures/security/reentrancy-invulenarble.js
+++ b/test/fixtures/security/reentrancy-invulenarble.js
@@ -1,4 +1,4 @@
-const { contractWith, funcWith } = require('./../../common/contract-builder')
+const { contractWith, funcWith } = require('../../common/contract-builder')
 
 module.exports = [
   contractWith(`
@@ -24,5 +24,5 @@ module.exports = [
                 uint amount = shares[msg.sender];
                 msg.sender.transfer(amount);
                 shares[msg.sender] = 0;
-            `)
+            `),
 ]

--- a/test/fixtures/security/reentrancy-vulenarble.js
+++ b/test/fixtures/security/reentrancy-vulenarble.js
@@ -1,4 +1,4 @@
-const { contractWith } = require('./../../common/contract-builder')
+const { contractWith } = require('../../common/contract-builder')
 
 module.exports = [
   contractWith(`
@@ -18,5 +18,5 @@ module.exports = [
                     msg.sender.transfer(amount);
                     shares[msg.sender] = 0;
                 }
-            `)
+            `),
 ]

--- a/test/parse-error.js
+++ b/test/parse-error.js
@@ -1,6 +1,6 @@
 const assert = require('assert')
 const { assertErrorCount } = require('./common/asserts')
-const linter = require('./../lib/index')
+const linter = require('../lib/index')
 
 describe('Parse error', () => {
   it('should report parse errors', () => {
@@ -23,7 +23,7 @@ describe('Parse error', () => {
     )
 
     assertErrorCount(report, 2)
-    const messages = report.reports.map(error => error.message)
+    const messages = report.reports.map((error) => error.message)
     assert.ok(messages[0].startsWith("Parse error: extraneous input '}' expecting"))
     assert.ok(messages[1].startsWith("Parse error: mismatched input '<EOF>' expecting"))
   })

--- a/test/rules/best-practises/code-complexity.js
+++ b/test/rules/best-practises/code-complexity.js
@@ -1,13 +1,13 @@
-const linter = require('./../../../lib/index')
-const { funcWith, modifierWith, multiLine } = require('./../../common/contract-builder')
-const { assertErrorCount, assertErrorMessage, assertNoErrors } = require('./../../common/asserts')
+const linter = require('../../../lib/index')
+const { funcWith, modifierWith, multiLine } = require('../../common/contract-builder')
+const { assertErrorCount, assertErrorMessage, assertNoErrors } = require('../../common/asserts')
 
 describe('Linter - code-complexity', () => {
   it('should raise error when cyclomatic complexity of a function is too high', () => {
     const report = linter.processStr(
       funcWith(require('../../fixtures/best-practises/code-complexity-high')),
       {
-        rules: { 'code-complexity': 'error' }
+        rules: { 'code-complexity': 'error' },
       }
     )
 
@@ -19,7 +19,7 @@ describe('Linter - code-complexity', () => {
     const report = linter.processStr(
       funcWith(require('../../fixtures/best-practises/code-complexity-low')),
       {
-        rules: { 'code-complexity': 'error' }
+        rules: { 'code-complexity': 'error' },
       }
     )
 
@@ -30,7 +30,7 @@ describe('Linter - code-complexity', () => {
     const report = linter.processStr(
       modifierWith(require('../../fixtures/best-practises/code-complexity-high')),
       {
-        rules: { 'code-complexity': 'error' }
+        rules: { 'code-complexity': 'error' },
       }
     )
 
@@ -57,7 +57,7 @@ describe('Linter - code-complexity', () => {
 
   it('should not raise error when cyclomatic complexity is equal to max allowed', () => {
     const report = linter.processStr(CUSTOM_CONFIG_CHECK_CODE, {
-      rules: { 'code-complexity': ['error', 12] }
+      rules: { 'code-complexity': ['error', 12] },
     })
 
     assertNoErrors(report)

--- a/test/rules/best-practises/function-max-lines.js
+++ b/test/rules/best-practises/function-max-lines.js
@@ -1,14 +1,14 @@
 const _ = require('lodash')
-const { assertErrorCount, assertNoErrors, assertErrorMessage } = require('./../../common/asserts')
-const linter = require('./../../../lib/index')
-const { funcWith } = require('./../../common/contract-builder')
+const { assertErrorCount, assertNoErrors, assertErrorMessage } = require('../../common/asserts')
+const linter = require('../../../lib/index')
+const { funcWith } = require('../../common/contract-builder')
 
 describe('Linter - function-max-lines', () => {
   it('should raise error for function with 51 lines', () => {
     const code = funcWith(emptyLines(51))
 
     const report = linter.processStr(code, {
-      rules: { 'function-max-lines': 'error' }
+      rules: { 'function-max-lines': 'error' },
     })
 
     assertErrorCount(report, 1)
@@ -19,7 +19,7 @@ describe('Linter - function-max-lines', () => {
     const code = funcWith(emptyLines(50))
 
     const report = linter.processStr(code, {
-      rules: { 'function-max-lines': 'error' }
+      rules: { 'function-max-lines': 'error' },
     })
 
     assertNoErrors(report)
@@ -29,7 +29,7 @@ describe('Linter - function-max-lines', () => {
     const code = funcWith(emptyLines(99))
 
     const report = linter.processStr(code, {
-      rules: { 'function-max-lines': ['error', 100] }
+      rules: { 'function-max-lines': ['error', 100] },
     })
 
     assertNoErrors(report)

--- a/test/rules/best-practises/max-line-length.js
+++ b/test/rules/best-practises/max-line-length.js
@@ -1,14 +1,14 @@
 const assert = require('assert')
-const { assertErrorMessage, assertLineNumber, assertNoErrors } = require('./../../common/asserts')
-const { contractWith } = require('./../../common/contract-builder')
-const linter = require('./../../../lib/index')
+const { assertErrorMessage, assertLineNumber, assertNoErrors } = require('../../common/asserts')
+const { contractWith } = require('../../common/contract-builder')
+const linter = require('../../../lib/index')
 
 describe('Linter - max-line-length', () => {
   it('should raise error when line length exceed 120', () => {
     const code = ' '.repeat(121)
 
     const report = linter.processStr(contractWith(code), {
-      rules: { 'max-line-length': 'error' }
+      rules: { 'max-line-length': 'error' },
     })
     assert.equal(report.errorCount, 1)
     assertErrorMessage(report, 0, 'Line length must be no more than')
@@ -19,7 +19,7 @@ describe('Linter - max-line-length', () => {
     const code = ' '.repeat(121)
 
     const report = linter.processStr(code, {
-      rules: { 'max-line-length': 'error' }
+      rules: { 'max-line-length': 'error' },
     })
 
     assert.equal(report.errorCount, 1)
@@ -30,7 +30,7 @@ describe('Linter - max-line-length', () => {
     const code = ' '.repeat(130)
 
     const report = linter.processStr(code, {
-      rules: { 'max-line-length': ['error', 130] }
+      rules: { 'max-line-length': ['error', 130] },
     })
 
     assertNoErrors(report)
@@ -40,7 +40,7 @@ describe('Linter - max-line-length', () => {
     const code = ' '.repeat(120)
 
     const report = linter.processStr(code, {
-      rules: { 'max-line-length': 'error' }
+      rules: { 'max-line-length': 'error' },
     })
 
     assertNoErrors(report)
@@ -51,7 +51,7 @@ describe('Linter - max-line-length', () => {
     const code = `${line}\n${line}\n`
 
     const report = linter.processStr(code, {
-      rules: { 'max-line-length': 'error' }
+      rules: { 'max-line-length': 'error' },
     })
 
     assertNoErrors(report)
@@ -62,7 +62,7 @@ describe('Linter - max-line-length', () => {
     const code = `${line}\n\r${line}\n\r`
 
     const report = linter.processStr(code, {
-      rules: { 'max-line-length': 'error' }
+      rules: { 'max-line-length': 'error' },
     })
 
     assertNoErrors(report)

--- a/test/rules/best-practises/max-states-count.js
+++ b/test/rules/best-practises/max-states-count.js
@@ -1,13 +1,13 @@
-const { assertErrorCount, assertNoErrors, assertErrorMessage } = require('./../../common/asserts')
-const linter = require('./../../../lib/index')
-const { contractWith, stateDef } = require('./../../common/contract-builder')
+const { assertErrorCount, assertNoErrors, assertErrorMessage } = require('../../common/asserts')
+const linter = require('../../../lib/index')
+const { contractWith, stateDef } = require('../../common/contract-builder')
 
 describe('Linter - max-states-count', () => {
   it('should raise error when count of states too big', () => {
     const code = require('../../fixtures/best-practises/number-of-states-high')
 
     const report = linter.processStr(code, {
-      rules: { 'max-states-count': ['error', 15] }
+      rules: { 'max-states-count': ['error', 15] },
     })
 
     assertErrorCount(report, 1)
@@ -18,7 +18,7 @@ describe('Linter - max-states-count', () => {
     const code = require('../../fixtures/best-practises/number-of-states-low')
 
     const report = linter.processStr(code, {
-      rules: { 'max-states-count': 'error' }
+      rules: { 'max-states-count': 'error' },
     })
 
     assertNoErrors(report)

--- a/test/rules/best-practises/no-empty-blocks.js
+++ b/test/rules/best-practises/no-empty-blocks.js
@@ -1,6 +1,6 @@
-const { assertNoWarnings, assertErrorMessage, assertWarnsCount } = require('./../../common/asserts')
-const linter = require('./../../../lib/index')
-const { contractWith, funcWith } = require('./../../common/contract-builder')
+const { assertNoWarnings, assertErrorMessage, assertWarnsCount } = require('../../common/asserts')
+const linter = require('../../../lib/index')
+const { contractWith, funcWith } = require('../../common/contract-builder')
 
 describe('Linter - no-empty-blocks', () => {
   const EMPTY_BLOCKS = [
@@ -8,13 +8,13 @@ describe('Linter - no-empty-blocks', () => {
     contractWith('struct Abc {  }'),
     contractWith('enum Abc {  }'),
     'contract A { }',
-    funcWith('assembly {  }')
+    funcWith('assembly {  }'),
   ]
 
-  EMPTY_BLOCKS.forEach(curData =>
+  EMPTY_BLOCKS.forEach((curData) =>
     it(`should raise warn for empty blocks ${label(curData)}`, () => {
       const report = linter.processStr(curData, {
-        rules: { 'no-empty-blocks': 'warn' }
+        rules: { 'no-empty-blocks': 'warn' },
       })
 
       assertWarnsCount(report, 1)
@@ -28,13 +28,13 @@ describe('Linter - no-empty-blocks', () => {
     contractWith('struct Abc { uint a; }'),
     contractWith('enum Abc { Test1 }'),
     'contract A { uint private a; }',
-    funcWith('assembly { "literal" }')
+    funcWith('assembly { "literal" }'),
   ]
 
-  BLOCKS_WITH_DEFINITIONS.forEach(curData =>
+  BLOCKS_WITH_DEFINITIONS.forEach((curData) =>
     it(`should not raise warn for blocks ${label(curData)}`, () => {
       const report = linter.processStr(curData, {
-        rules: { 'no-empty-blocks': 'warn' }
+        rules: { 'no-empty-blocks': 'warn' },
       })
 
       assertNoWarnings(report)
@@ -44,7 +44,7 @@ describe('Linter - no-empty-blocks', () => {
   it('should not raise error for default function', () => {
     const defaultFunction = contractWith('function () public payable {}')
     const report = linter.processStr(defaultFunction, {
-      rules: { 'no-empty-blocks': 'warn' }
+      rules: { 'no-empty-blocks': 'warn' },
     })
 
     assertNoWarnings(report)

--- a/test/rules/best-practises/no-unused-vars.js
+++ b/test/rules/best-practises/no-unused-vars.js
@@ -1,6 +1,6 @@
-const { assertNoWarnings, assertErrorMessage, assertWarnsCount } = require('./../../common/asserts')
-const linter = require('./../../../lib/index')
-const { contractWith, funcWith, multiLine } = require('./../../common/contract-builder')
+const { assertNoWarnings, assertErrorMessage, assertWarnsCount } = require('../../common/asserts')
+const linter = require('../../../lib/index')
+const { contractWith, funcWith, multiLine } = require('../../common/contract-builder')
 
 describe('Linter - no-unused-vars', () => {
   const UNUSED_VARS = [
@@ -9,13 +9,13 @@ describe('Linter - no-unused-vars', () => {
     funcWith('var (a) = 1;'),
     contractWith('function a(uint a, uint b) public { uint c = a + b; }'),
     contractWith('function foo(uint a) { assembly { let t := a } }'),
-    contractWith('function foo(uint a) { uint b = a; } ')
+    contractWith('function foo(uint a) { uint b = a; } '),
   ]
 
-  UNUSED_VARS.forEach(curData =>
+  UNUSED_VARS.forEach((curData) =>
     it(`should raise warn for vars ${label(curData)}`, () => {
       const report = linter.processStr(curData, {
-        rules: { 'no-unused-vars': 'warn' }
+        rules: { 'no-unused-vars': 'warn' },
       })
 
       assertWarnsCount(report, 1)
@@ -63,13 +63,13 @@ describe('Linter - no-unused-vars', () => {
         '  return (c, d);                                   ',
         '}                                                  '
       )
-    )
+    ),
   ]
 
-  USED_VARS.forEach(curData =>
+  USED_VARS.forEach((curData) =>
     it(`should not raise warn for vars ${label(curData)}`, () => {
       const report = linter.processStr(curData, {
-        rules: { 'no-unused-vars': 'warn' }
+        rules: { 'no-unused-vars': 'warn' },
       })
 
       assertNoWarnings(report)
@@ -84,7 +84,7 @@ function withdrawalAllowed(address) public view override returns (bool) {
     `)
 
     const report = linter.processStr(code, {
-      rules: { 'no-unused-vars': 'warn' }
+      rules: { 'no-unused-vars': 'warn' },
     })
 
     assertNoWarnings(report)

--- a/test/rules/best-practises/payable-fallback.js
+++ b/test/rules/best-practises/payable-fallback.js
@@ -1,13 +1,13 @@
-const { assertNoWarnings, assertErrorMessage, assertWarnsCount } = require('./../../common/asserts')
-const linter = require('./../../../lib/index')
-const { contractWith } = require('./../../common/contract-builder')
+const { assertNoWarnings, assertErrorMessage, assertWarnsCount } = require('../../common/asserts')
+const linter = require('../../../lib/index')
+const { contractWith } = require('../../common/contract-builder')
 
 describe('Linter - payable-fallback', () => {
   it('should raise warn when fallback is not payable', () => {
     const code = require('../../fixtures/best-practises/fallback-not-payable')
 
     const report = linter.processStr(code, {
-      rules: { 'payable-fallback': 'warn' }
+      rules: { 'payable-fallback': 'warn' },
     })
 
     assertWarnsCount(report, 1)
@@ -18,7 +18,7 @@ describe('Linter - payable-fallback', () => {
     const code = require('../../fixtures/best-practises/fallback-payable')
 
     const report = linter.processStr(code, {
-      rules: { 'payable-fallback': 'warn' }
+      rules: { 'payable-fallback': 'warn' },
     })
 
     assertNoWarnings(report)
@@ -28,7 +28,7 @@ describe('Linter - payable-fallback', () => {
     const code = contractWith('function f() {} function g() payable {}')
 
     const report = linter.processStr(code, {
-      rules: { 'payable-fallback': 'warn' }
+      rules: { 'payable-fallback': 'warn' },
     })
 
     assertNoWarnings(report)

--- a/test/rules/best-practises/reason-string.js
+++ b/test/rules/best-practises/reason-string.js
@@ -4,17 +4,17 @@ const {
   assertNoErrors,
   assertErrorMessage,
   assertWarnsCount,
-  assertErrorCount
-} = require('./../../common/asserts')
-const linter = require('./../../../lib/index')
-const { funcWith } = require('./../../common/contract-builder')
+  assertErrorCount,
+} = require('../../common/asserts')
+const linter = require('../../../lib/index')
+const { funcWith } = require('../../common/contract-builder')
 
 describe('Linter - reason-string', () => {
   it('should raise reason string is mandatory for require', () => {
     const code = require('../../fixtures/best-practises/require-without-reason')
 
     const report = linter.processStr(code, {
-      rules: { 'reason-string': ['warn', { maxLength: 5 }] }
+      rules: { 'reason-string': ['warn', { maxLength: 5 }] },
     })
 
     assert.ok(report.warningCount > 0)
@@ -28,7 +28,7 @@ describe('Linter - reason-string', () => {
     `)
 
     const report = linter.processStr(code, {
-      rules: { 'reason-string': ['error', { maxLength: 5 }] }
+      rules: { 'reason-string': ['error', { maxLength: 5 }] },
     })
 
     assert.ok(report.errorCount > 0)
@@ -42,7 +42,7 @@ describe('Linter - reason-string', () => {
     `)
 
     const report = linter.processStr(code, {
-      rules: { 'reason-string': ['warn', { maxLength: 5 }] }
+      rules: { 'reason-string': ['warn', { maxLength: 5 }] },
     })
 
     assert.ok(report.warningCount > 0)
@@ -56,7 +56,7 @@ describe('Linter - reason-string', () => {
     `)
 
     const report = linter.processStr(code, {
-      rules: { 'reason-string': ['error', { maxLength: 5 }] }
+      rules: { 'reason-string': ['error', { maxLength: 5 }] },
     })
 
     assert.ok(report.errorCount > 0)
@@ -68,7 +68,7 @@ describe('Linter - reason-string', () => {
     const code = require('../../fixtures/best-practises/require-with-reason')
 
     const report = linter.processStr(code, {
-      rules: { 'reason-string': ['warn', { maxLength: 31 }] }
+      rules: { 'reason-string': ['warn', { maxLength: 31 }] },
     })
 
     assertNoWarnings(report)
@@ -81,7 +81,7 @@ describe('Linter - reason-string', () => {
     `)
 
     const report = linter.processStr(code, {
-      rules: { 'reason-string': ['error', { maxLength: 50 }] }
+      rules: { 'reason-string': ['error', { maxLength: 50 }] },
     })
 
     assertNoWarnings(report)
@@ -95,7 +95,7 @@ describe('Linter - reason-string', () => {
     `)
 
     const report = linter.processStr(code, {
-      rules: { 'reason-string': ['error', { maxLength: 50 }] }
+      rules: { 'reason-string': ['error', { maxLength: 50 }] },
     })
 
     assertNoWarnings(report)

--- a/test/rules/deprecations/constructor-syntax.js
+++ b/test/rules/deprecations/constructor-syntax.js
@@ -1,8 +1,8 @@
 const assert = require('assert')
-const linter = require('./../../../lib/index')
-const { multiLine } = require('./../../common/contract-builder')
-const { assertErrorMessage } = require('./../../common/asserts')
-const BaseDeprecation = require('./../../../lib/rules/deprecations/base-deprecation')
+const linter = require('../../../lib/index')
+const { multiLine } = require('../../common/contract-builder')
+const { assertErrorMessage } = require('../../common/asserts')
+const BaseDeprecation = require('../../../lib/rules/deprecations/base-deprecation')
 
 describe('Linter - constructor-syntax', () => {
   it('should raise a warning for old-style constructors', () => {
@@ -14,7 +14,7 @@ describe('Linter - constructor-syntax', () => {
       '}                                ' // 5
     )
     const report = linter.processStr(code, {
-      rules: { 'constructor-syntax': 'warn' }
+      rules: { 'constructor-syntax': 'warn' },
     })
 
     assert.equal(report.warningCount, 1)
@@ -30,7 +30,7 @@ describe('Linter - constructor-syntax', () => {
       '}                                ' // 5
     )
     const report = linter.processStr(code, {
-      rules: { 'constructor-syntax': 'warn' }
+      rules: { 'constructor-syntax': 'warn' },
     })
     assert.equal(report.warningCount, 0)
   })
@@ -44,7 +44,7 @@ describe('Linter - constructor-syntax', () => {
       '}                                ' // 5
     )
     const report = linter.processStr(code, {
-      rules: { 'constructor-syntax': 'warn' }
+      rules: { 'constructor-syntax': 'warn' },
     })
     assert.equal(report.warningCount, 0)
   })
@@ -58,7 +58,7 @@ describe('Linter - constructor-syntax', () => {
       '}                                ' // 5
     )
     const report = linter.processStr(code, {
-      rules: { 'constructor-syntax': 'error' }
+      rules: { 'constructor-syntax': 'error' },
     })
     assert.equal(report.errorCount, 1)
     assertErrorMessage(report, 0, 'Constructor keyword')

--- a/test/rules/miscellaneous/comprehensive-interface.js
+++ b/test/rules/miscellaneous/comprehensive-interface.js
@@ -1,12 +1,12 @@
 const assert = require('assert')
-const linter = require('./../../../lib/index')
+const linter = require('../../../lib/index')
 
 describe('Linter - comprehensive-interface', () => {
   it('should raise an error', () => {
     const code = require('../../fixtures/miscellaneous/public-function-no-override')
 
     const report = linter.processStr(code, {
-      rules: { 'comprehensive-interface': 'error' }
+      rules: { 'comprehensive-interface': 'error' },
     })
 
     assert.equal(report.errorCount, 1)
@@ -21,7 +21,7 @@ describe('Linter - comprehensive-interface', () => {
     const code = require('../../fixtures/miscellaneous/public-function-with-override')
 
     const report = linter.processStr(code, {
-      rules: { 'comprehensive-interface': 'error' }
+      rules: { 'comprehensive-interface': 'error' },
     })
 
     assert.equal(report.errorCount, 0)

--- a/test/rules/miscellaneous/quotes.js
+++ b/test/rules/miscellaneous/quotes.js
@@ -1,8 +1,8 @@
 const assert = require('assert')
-const linter = require('./../../../lib/index')
-const { contractWith, funcWith } = require('./../../common/contract-builder')
-const { storeAsFile, removeTmpFiles } = require('./../../common/utils')
-const { assertNoErrors, assertErrorCount } = require('./../../common/asserts')
+const linter = require('../../../lib/index')
+const { contractWith, funcWith } = require('../../common/contract-builder')
+const { storeAsFile, removeTmpFiles } = require('../../common/utils')
+const { assertNoErrors, assertErrorCount } = require('../../common/asserts')
 
 describe('Linter - quotes', () => {
   after(() => {
@@ -13,7 +13,7 @@ describe('Linter - quotes', () => {
     const code = require('../../fixtures/miscellaneous/string-with-single-quotes')
 
     const report = linter.processStr(code, {
-      rules: { quotes: 'error' }
+      rules: { quotes: 'error' },
     })
 
     assert.equal(report.errorCount, 1)
@@ -24,7 +24,7 @@ describe('Linter - quotes', () => {
     const code = "import * from 'lib.sol';"
 
     const report = linter.processStr(code, {
-      rules: { quotes: 'error' }
+      rules: { quotes: 'error' },
     })
 
     assert.equal(report.errorCount, 1)
@@ -52,10 +52,10 @@ describe('Linter - quotes', () => {
   const ERROR_ASSEMBLY_CLAUSES = [
     "assembly { 'abc' }",
     "assembly { dataSize('uint') }",
-    "assembly { linkerSymbol('uint') }"
+    "assembly { linkerSymbol('uint') }",
   ]
 
-  ERROR_ASSEMBLY_CLAUSES.forEach(curText =>
+  ERROR_ASSEMBLY_CLAUSES.forEach((curText) =>
     it(`should raise quotes error in assembly clause ${curText}`, () => {
       const code = funcWith(curText)
 
@@ -70,7 +70,7 @@ describe('Linter - quotes', () => {
     const filePath = storeAsFile(require('../../fixtures/miscellaneous/string-with-double-quotes'))
 
     const report = linter.processFile(filePath, {
-      rules: { quotes: 'error' }
+      rules: { quotes: 'error' },
     })
 
     assertNoErrors(report)
@@ -81,7 +81,7 @@ describe('Linter - quotes', () => {
     const filePath = storeAsFile(contractWith("string private a = 'test';"))
 
     const reports = linter.processPath(filePath, {
-      rules: { quotes: 'error' }
+      rules: { quotes: 'error' },
     })
 
     assertErrorCount(reports[0], 1)

--- a/test/rules/naming/const-name-snakecase.js
+++ b/test/rules/naming/const-name-snakecase.js
@@ -1,13 +1,13 @@
 const assert = require('assert')
-const linter = require('./../../../lib/index')
-const contractWith = require('./../../common/contract-builder').contractWith
+const linter = require('../../../lib/index')
+const contractWith = require('../../common/contract-builder').contractWith
 
 describe('Linter - const-name-snakecase', () => {
   it('should raise const name error', () => {
     const code = contractWith('uint private constant a;')
 
     const report = linter.processStr(code, {
-      rules: { 'const-name-snakecase': 'error' }
+      rules: { 'const-name-snakecase': 'error' },
     })
 
     assert.equal(report.errorCount, 1)
@@ -18,7 +18,7 @@ describe('Linter - const-name-snakecase', () => {
     const code = contractWith('uint32 private constant THE_CONSTANT = 10;')
 
     const report = linter.processStr(code, {
-      rules: { 'const-name-snakecase': 'error' }
+      rules: { 'const-name-snakecase': 'error' },
     })
 
     assert.equal(report.errorCount, 0)
@@ -28,7 +28,7 @@ describe('Linter - const-name-snakecase', () => {
     const code = contractWith('uint32 private constant _THE_CONSTANT = 10;')
 
     const report = linter.processStr(code, {
-      rules: { 'const-name-snakecase': 'error' }
+      rules: { 'const-name-snakecase': 'error' },
     })
 
     assert.equal(report.errorCount, 0)
@@ -38,7 +38,7 @@ describe('Linter - const-name-snakecase', () => {
     const code = contractWith('uint32 private constant __THE_CONSTANT = 10;')
 
     const report = linter.processStr(code, {
-      rules: { 'const-name-snakecase': 'error' }
+      rules: { 'const-name-snakecase': 'error' },
     })
 
     assert.equal(report.errorCount, 0)
@@ -48,7 +48,7 @@ describe('Linter - const-name-snakecase', () => {
     const code = contractWith('uint32 private constant ___THE_CONSTANT = 10;')
 
     const report = linter.processStr(code, {
-      rules: { 'const-name-snakecase': 'error' }
+      rules: { 'const-name-snakecase': 'error' },
     })
 
     assert.equal(report.errorCount, 1)

--- a/test/rules/naming/contract-name-camelcase.js
+++ b/test/rules/naming/contract-name-camelcase.js
@@ -1,13 +1,13 @@
 const assert = require('assert')
-const linter = require('./../../../lib/index')
-const contractWith = require('./../../common/contract-builder').contractWith
+const linter = require('../../../lib/index')
+const contractWith = require('../../common/contract-builder').contractWith
 
 describe('Linter - contract-name-camelcase', () => {
   it('should raise struct name error', () => {
     const code = contractWith('struct a {}')
 
     const report = linter.processStr(code, {
-      rules: { 'contract-name-camelcase': 'error' }
+      rules: { 'contract-name-camelcase': 'error' },
     })
 
     assert.equal(report.errorCount, 1)
@@ -18,7 +18,7 @@ describe('Linter - contract-name-camelcase', () => {
     const code = 'contract a {}'
 
     const report = linter.processStr(code, {
-      rules: { 'contract-name-camelcase': 'error' }
+      rules: { 'contract-name-camelcase': 'error' },
     })
 
     assert.equal(report.errorCount, 1)
@@ -29,7 +29,7 @@ describe('Linter - contract-name-camelcase', () => {
     const code = contractWith('enum abc {}')
 
     const report = linter.processStr(code, {
-      rules: { 'contract-name-camelcase': 'error' }
+      rules: { 'contract-name-camelcase': 'error' },
     })
 
     assert.equal(report.errorCount, 1)

--- a/test/rules/naming/event-name-camelcase.js
+++ b/test/rules/naming/event-name-camelcase.js
@@ -1,13 +1,13 @@
 const assert = require('assert')
-const linter = require('./../../../lib/index')
-const contractWith = require('./../../common/contract-builder').contractWith
+const linter = require('../../../lib/index')
+const contractWith = require('../../common/contract-builder').contractWith
 
 describe('Linter - event-name-camelcase', () => {
   it('should raise event name error for event in mixedCase', () => {
     const code = contractWith('event event1(uint a);')
 
     const report = linter.processStr(code, {
-      rules: { 'event-name-camelcase': 'error' }
+      rules: { 'event-name-camelcase': 'error' },
     })
 
     assert.equal(report.errorCount, 1)

--- a/test/rules/naming/func-name-mixedcase.js
+++ b/test/rules/naming/func-name-mixedcase.js
@@ -1,13 +1,13 @@
 const assert = require('assert')
-const linter = require('./../../../lib/index')
-const contractWith = require('./../../common/contract-builder').contractWith
+const linter = require('../../../lib/index')
+const contractWith = require('../../common/contract-builder').contractWith
 
 describe('Linter - func-name-mixedcase', () => {
   it('should raise incorrect func name error', () => {
     const code = contractWith('function AFuncName () public {}')
 
     const report = linter.processStr(code, {
-      rules: { 'func-name-mixedcase': 'error' }
+      rules: { 'func-name-mixedcase': 'error' },
     })
 
     assert.equal(report.errorCount, 1)
@@ -18,7 +18,7 @@ describe('Linter - func-name-mixedcase', () => {
     const code = contractWith('function aFunc1Nam23e () public {}')
 
     const report = linter.processStr(code, {
-      rules: { 'func-name-mixedcase': 'error' }
+      rules: { 'func-name-mixedcase': 'error' },
     })
 
     assert.equal(report.errorCount, 0)

--- a/test/rules/naming/func-param-name-mixedcase.js
+++ b/test/rules/naming/func-param-name-mixedcase.js
@@ -1,13 +1,13 @@
 const assert = require('assert')
-const linter = require('./../../../lib/index')
-const contractWith = require('./../../common/contract-builder').contractWith
+const linter = require('../../../lib/index')
+const contractWith = require('../../common/contract-builder').contractWith
 
 describe('Linter - func-param-name-mixedcase', () => {
   it('should raise incorrect func param name error', () => {
     const code = contractWith('function funcName (uint A) public {}')
 
     const report = linter.processStr(code, {
-      rules: { 'func-param-name-mixedcase': 'error' }
+      rules: { 'func-param-name-mixedcase': 'error' },
     })
 
     assert.equal(report.errorCount, 1)
@@ -18,7 +18,7 @@ describe('Linter - func-param-name-mixedcase', () => {
     const code = contractWith('event Event1(uint B);')
 
     const report = linter.processStr(code, {
-      rules: { 'func-param-name-mixedcase': 'error' }
+      rules: { 'func-param-name-mixedcase': 'error' },
     })
 
     assert.equal(report.errorCount, 1)

--- a/test/rules/naming/modifier-name-mixedcase.js
+++ b/test/rules/naming/modifier-name-mixedcase.js
@@ -1,13 +1,13 @@
 const assert = require('assert')
-const linter = require('./../../../lib/index')
-const contractWith = require('./../../common/contract-builder').contractWith
+const linter = require('../../../lib/index')
+const contractWith = require('../../common/contract-builder').contractWith
 
 describe('Linter - modifier-name-mixedcase', () => {
   it('should raise modifier name error', () => {
     const code = contractWith('modifier owned_by(address a) { }')
 
     const report = linter.processStr(code, {
-      rules: { 'modifier-name-mixedcase': 'error' }
+      rules: { 'modifier-name-mixedcase': 'error' },
     })
 
     assert.equal(report.errorCount, 1)
@@ -18,7 +18,7 @@ describe('Linter - modifier-name-mixedcase', () => {
     const code = contractWith('modifier ownedBy(address a) { }')
 
     const report = linter.processStr(code, {
-      rules: { 'modifier-name-mixedcase': 'error' }
+      rules: { 'modifier-name-mixedcase': 'error' },
     })
 
     assert.equal(report.errorCount, 0)

--- a/test/rules/naming/private-vars-leading-underscore.js
+++ b/test/rules/naming/private-vars-leading-underscore.js
@@ -1,6 +1,6 @@
 const assert = require('assert')
-const linter = require('./../../../lib/index')
-const { contractWith, libraryWith } = require('./../../common/contract-builder')
+const linter = require('../../../lib/index')
+const { contractWith, libraryWith } = require('../../common/contract-builder')
 
 describe('Linter - private-vars-leading-underscore', () => {
   const SHOULD_WARN_CASES = [
@@ -19,14 +19,14 @@ describe('Linter - private-vars-leading-underscore', () => {
     contractWith('function _foo() external {}'),
     libraryWith('function _foo() {}'),
     libraryWith('function _foo() public {}'),
-    libraryWith('function _foo() internal {}')
+    libraryWith('function _foo() internal {}'),
   ]
   const SHOULD_WARN_STRICT_CASES = [
     contractWith('function foo() { uint _bar; }'),
     contractWith('function foo(uint _bar) {}'),
     contractWith('function foo() returns (uint256 _bar) {}'),
     libraryWith('function foo() returns (uint256 _bar) {}'),
-    libraryWith('function foo(uint _bar) {}')
+    libraryWith('function foo(uint _bar) {}'),
   ]
   const SHOULD_NOT_WARN_CASES = [
     // don't warn when private/internal names start with _
@@ -57,13 +57,13 @@ describe('Linter - private-vars-leading-underscore', () => {
     libraryWith('function foo(uint bar) {}'),
     libraryWith('function foo() { uint bar; }'),
     libraryWith('function foo() returns (uint256) {}'),
-    libraryWith('function foo() returns (uint256 bar) {}')
+    libraryWith('function foo() returns (uint256 bar) {}'),
   ]
 
   SHOULD_WARN_CASES.forEach((code, index) => {
     it(`should emit a warning (${index})`, () => {
       const report = linter.processStr(code, {
-        rules: { 'private-vars-leading-underscore': 'error' }
+        rules: { 'private-vars-leading-underscore': 'error' },
       })
 
       assert.equal(report.errorCount, 1)
@@ -73,7 +73,7 @@ describe('Linter - private-vars-leading-underscore', () => {
   SHOULD_WARN_STRICT_CASES.concat(SHOULD_NOT_WARN_CASES).forEach((code, index) => {
     it(`should not emit a warning (strict) (${index})`, () => {
       const report = linter.processStr(code, {
-        rules: { 'private-vars-leading-underscore': 'error' }
+        rules: { 'private-vars-leading-underscore': 'error' },
       })
 
       assert.equal(report.errorCount, 0)
@@ -83,7 +83,7 @@ describe('Linter - private-vars-leading-underscore', () => {
   SHOULD_NOT_WARN_CASES.forEach((code, index) => {
     it(`should not emit a warning (${index})`, () => {
       const report = linter.processStr(code, {
-        rules: { 'private-vars-leading-underscore': ['error', { strict: true }] }
+        rules: { 'private-vars-leading-underscore': ['error', { strict: true }] },
       })
 
       assert.equal(report.errorCount, 0)
@@ -93,7 +93,7 @@ describe('Linter - private-vars-leading-underscore', () => {
   SHOULD_WARN_STRICT_CASES.forEach((code, index) => {
     it(`should not emit a warning (strict) (${index})`, () => {
       const report = linter.processStr(code, {
-        rules: { 'private-vars-leading-underscore': ['error', { strict: true }] }
+        rules: { 'private-vars-leading-underscore': ['error', { strict: true }] },
       })
 
       assert.equal(report.errorCount, 1)

--- a/test/rules/naming/use-forbidden-name.js
+++ b/test/rules/naming/use-forbidden-name.js
@@ -1,13 +1,13 @@
 const assert = require('assert')
-const linter = require('./../../../lib/index')
-const funcWith = require('./../../common/contract-builder').funcWith
+const linter = require('../../../lib/index')
+const funcWith = require('../../common/contract-builder').funcWith
 
 describe('Linter - use-forbidden-name', () => {
   it('should raise forbidden name error', () => {
     const code = funcWith('uint l = 0;')
 
     const report = linter.processStr(code, {
-      rules: { 'no-unused-vars': 'error', 'use-forbidden-name': 'error' }
+      rules: { 'no-unused-vars': 'error', 'use-forbidden-name': 'error' },
     })
 
     assert.equal(report.errorCount, 2)

--- a/test/rules/naming/var-name-mixedcase.js
+++ b/test/rules/naming/var-name-mixedcase.js
@@ -1,36 +1,36 @@
 const assert = require('assert')
-const linter = require('./../../../lib/index')
-const contractWith = require('./../../common/contract-builder').contractWith
-const funcWith = require('./../../common/contract-builder').funcWith
+const linter = require('../../../lib/index')
+const contractWith = require('../../common/contract-builder').contractWith
+const funcWith = require('../../common/contract-builder').funcWith
 
 describe('Linter - var-name-mixedcase', () => {
   it('should raise incorrect var name error', () => {
     const code = funcWith('var (a, B);')
 
     const report = linter.processStr(code, {
-      rules: { 'no-unused-vars': 'error', 'var-name-mixedcase': 'error' }
+      rules: { 'no-unused-vars': 'error', 'var-name-mixedcase': 'error' },
     })
 
     assert.ok(report.errorCount > 0)
-    assert.ok(report.messages.map(i => i.message).some(i => i.includes('name')))
+    assert.ok(report.messages.map((i) => i.message).some((i) => i.includes('name')))
   })
 
   it('should raise incorrect var name error for typed declaration', () => {
     const code = funcWith('uint B = 1;')
 
     const report = linter.processStr(code, {
-      rules: { 'no-unused-vars': 'error', 'var-name-mixedcase': 'error' }
+      rules: { 'no-unused-vars': 'error', 'var-name-mixedcase': 'error' },
     })
 
     assert.ok(report.errorCount > 0)
-    assert.ok(report.messages.map(i => i.message).some(i => i.includes('name')))
+    assert.ok(report.messages.map((i) => i.message).some((i) => i.includes('name')))
   })
 
   it('should raise incorrect var name error for state declaration', () => {
     const code = contractWith('uint32 private D = 10;')
 
     const report = linter.processStr(code, {
-      rules: { 'no-unused-vars': 'error', 'var-name-mixedcase': 'error' }
+      rules: { 'no-unused-vars': 'error', 'var-name-mixedcase': 'error' },
     })
 
     assert.equal(report.errorCount, 1)
@@ -41,7 +41,7 @@ describe('Linter - var-name-mixedcase', () => {
     const code = contractWith('uint32 private constant D = 10;')
 
     const report = linter.processStr(code, {
-      rules: { 'no-unused-vars': 'error', 'var-name-mixedcase': 'error' }
+      rules: { 'no-unused-vars': 'error', 'var-name-mixedcase': 'error' },
     })
 
     assert.equal(report.errorCount, 0)

--- a/test/rules/order/func-order.js
+++ b/test/rules/order/func-order.js
@@ -1,6 +1,6 @@
 const assert = require('assert')
-const linter = require('./../../../lib/index')
-const contractWith = require('./../../common/contract-builder').contractWith
+const linter = require('../../../lib/index')
+const contractWith = require('../../common/contract-builder').contractWith
 
 describe('Linter - func-order', () => {
   it('should raise incorrect function order error I', () => {
@@ -10,7 +10,7 @@ describe('Linter - func-order', () => {
             `)
 
     const report = linter.processStr(code, {
-      rules: { 'func-order': 'error' }
+      rules: { 'func-order': 'error' },
     })
 
     assert.equal(report.errorCount, 1)
@@ -24,7 +24,7 @@ describe('Linter - func-order', () => {
             `)
 
     const report = linter.processStr(code, {
-      rules: { 'func-order': 'error' }
+      rules: { 'func-order': 'error' },
     })
 
     assert.equal(report.errorCount, 1)
@@ -38,7 +38,7 @@ describe('Linter - func-order', () => {
           `)
 
     const report = linter.processStr(code, {
-      rules: { 'func-order': 'error' }
+      rules: { 'func-order': 'error' },
     })
 
     assert.equal(report.errorCount, 1)
@@ -52,7 +52,7 @@ describe('Linter - func-order', () => {
             `)
 
     const report = linter.processStr(code, {
-      rules: { 'func-order': 'error' }
+      rules: { 'func-order': 'error' },
     })
 
     assert.equal(report.errorCount, 1)
@@ -66,7 +66,7 @@ describe('Linter - func-order', () => {
             `)
 
     const report = linter.processStr(code, {
-      rules: { 'func-order': 'error' }
+      rules: { 'func-order': 'error' },
     })
 
     assert.equal(report.errorCount, 0)
@@ -76,7 +76,7 @@ describe('Linter - func-order', () => {
     const code = require('../../fixtures/order/func-order-constructor-first')
 
     const report = linter.processStr(code, {
-      rules: { 'func-order': 'error' }
+      rules: { 'func-order': 'error' },
     })
 
     assert.equal(report.errorCount, 0)
@@ -86,7 +86,7 @@ describe('Linter - func-order', () => {
     const code = require('../../fixtures/order/func-order-constructor-not-first')
 
     const report = linter.processStr(code, {
-      rules: { 'func-order': 'error' }
+      rules: { 'func-order': 'error' },
     })
     assert.equal(report.errorCount, 1)
     assert.ok(report.messages[0].message.includes('Function order is incorrect'))
@@ -99,7 +99,7 @@ describe('Linter - func-order', () => {
             `)
 
     const report = linter.processStr(code, {
-      rules: { 'func-order': 'error' }
+      rules: { 'func-order': 'error' },
     })
 
     assert.equal(report.errorCount, 0)

--- a/test/rules/order/imports-on-top.js
+++ b/test/rules/order/imports-on-top.js
@@ -1,5 +1,5 @@
 const assert = require('assert')
-const linter = require('./../../../lib/index')
+const linter = require('../../../lib/index')
 
 describe('Linter - imports-on-top', () => {
   it('should raise import not on top error', () => {
@@ -11,7 +11,7 @@ describe('Linter - imports-on-top', () => {
             `
 
     const report = linter.processStr(code, {
-      rules: { 'imports-on-top': 'error' }
+      rules: { 'imports-on-top': 'error' },
     })
 
     assert.equal(report.errorCount, 1)
@@ -28,7 +28,7 @@ describe('Linter - imports-on-top', () => {
             `
 
     const report = linter.processStr(code, {
-      rules: { 'imports-on-top': 'error' }
+      rules: { 'imports-on-top': 'error' },
     })
 
     assert.equal(report.errorCount, 0)

--- a/test/rules/order/ordering.js
+++ b/test/rules/order/ordering.js
@@ -1,6 +1,6 @@
 const assert = require('assert')
-const linter = require('./../../../lib/index')
-const contractWith = require('./../../common/contract-builder').contractWith
+const linter = require('../../../lib/index')
+const contractWith = require('../../common/contract-builder').contractWith
 const correctExamples = require('../../fixtures/order/ordering-correct')
 const incorrectExamples = require('../../fixtures/order/ordering-incorrect')
 
@@ -9,7 +9,7 @@ describe('Linter - ordering', () => {
     correctExamples.forEach(({ code, description }) => {
       it(description, () => {
         const report = linter.processStr(code, {
-          rules: { ordering: 'error' }
+          rules: { ordering: 'error' },
         })
 
         assert.equal(report.errorCount, 0)
@@ -21,7 +21,7 @@ describe('Linter - ordering', () => {
     incorrectExamples.forEach(({ code, description }) => {
       it(description, () => {
         const report = linter.processStr(code, {
-          rules: { ordering: 'error' }
+          rules: { ordering: 'error' },
         })
 
         assert.equal(report.errorCount, 1)
@@ -36,7 +36,7 @@ describe('Linter - ordering', () => {
             `)
 
     const report = linter.processStr(code, {
-      rules: { ordering: 'error' }
+      rules: { ordering: 'error' },
     })
 
     assert.equal(report.errorCount, 1)
@@ -50,7 +50,7 @@ describe('Linter - ordering', () => {
             `)
 
     const report = linter.processStr(code, {
-      rules: { ordering: 'error' }
+      rules: { ordering: 'error' },
     })
 
     assert.equal(report.errorCount, 1)
@@ -64,7 +64,7 @@ describe('Linter - ordering', () => {
           `)
 
     const report = linter.processStr(code, {
-      rules: { ordering: 'error' }
+      rules: { ordering: 'error' },
     })
 
     assert.equal(report.errorCount, 1)
@@ -78,7 +78,7 @@ describe('Linter - ordering', () => {
             `)
 
     const report = linter.processStr(code, {
-      rules: { ordering: 'error' }
+      rules: { ordering: 'error' },
     })
 
     assert.equal(report.errorCount, 1)
@@ -92,7 +92,7 @@ describe('Linter - ordering', () => {
             `)
 
     const report = linter.processStr(code, {
-      rules: { ordering: 'error' }
+      rules: { ordering: 'error' },
     })
 
     assert.equal(report.errorCount, 1)
@@ -106,7 +106,7 @@ describe('Linter - ordering', () => {
             `)
 
     const report = linter.processStr(code, {
-      rules: { ordering: 'error' }
+      rules: { ordering: 'error' },
     })
 
     assert.equal(report.errorCount, 0)
@@ -119,7 +119,7 @@ describe('Linter - ordering', () => {
             `)
 
     const report = linter.processStr(code, {
-      rules: { ordering: 'error' }
+      rules: { ordering: 'error' },
     })
 
     assert.equal(report.errorCount, 0)
@@ -129,7 +129,7 @@ describe('Linter - ordering', () => {
     const code = require('../../fixtures/order/func-order-constructor-first')
 
     const report = linter.processStr(code, {
-      rules: { ordering: 'error' }
+      rules: { ordering: 'error' },
     })
 
     assert.equal(report.errorCount, 0)
@@ -139,7 +139,7 @@ describe('Linter - ordering', () => {
     const code = require('../../fixtures/order/func-order-constructor-not-first')
 
     const report = linter.processStr(code, {
-      rules: { ordering: 'error' }
+      rules: { ordering: 'error' },
     })
     assert.equal(report.errorCount, 1)
     assert.ok(report.messages[0].message.includes('Function order is incorrect'))
@@ -152,7 +152,7 @@ describe('Linter - ordering', () => {
             `)
 
     const report = linter.processStr(code, {
-      rules: { ordering: 'error' }
+      rules: { ordering: 'error' },
     })
 
     assert.equal(report.errorCount, 0)
@@ -166,7 +166,7 @@ describe('Linter - ordering', () => {
     `
 
     const report = linter.processStr(code, {
-      rules: { ordering: 'error' }
+      rules: { ordering: 'error' },
     })
 
     assert.equal(report.errorCount, 1)
@@ -180,7 +180,7 @@ describe('Linter - ordering', () => {
     `)
 
     const report = linter.processStr(code, {
-      rules: { ordering: 'error' }
+      rules: { ordering: 'error' },
     })
 
     assert.equal(report.errorCount, 1)

--- a/test/rules/order/visibility-modifier-order.js
+++ b/test/rules/order/visibility-modifier-order.js
@@ -1,13 +1,13 @@
 const assert = require('assert')
-const linter = require('./../../../lib/index')
-const { contractWith } = require('./../../common/contract-builder')
+const linter = require('../../../lib/index')
+const { contractWith } = require('../../common/contract-builder')
 
 describe('Linter - visibility-modifier-order', () => {
   it('should raise visibility modifier error', () => {
     const code = require('../../fixtures/order/visibility-modifier-not-first')
 
     const report = linter.processStr(code, {
-      rules: { 'visibility-modifier-order': 'error' }
+      rules: { 'visibility-modifier-order': 'error' },
     })
 
     assert.equal(report.errorCount, 1)
@@ -17,7 +17,7 @@ describe('Linter - visibility-modifier-order', () => {
     const code = require('../../fixtures/order/visibility-modifier-first')
 
     const report = linter.processStr(code, {
-      rules: { 'visibility-modifier-order': 'error' }
+      rules: { 'visibility-modifier-order': 'error' },
     })
 
     assert.equal(report.errorCount, 0)
@@ -27,7 +27,7 @@ describe('Linter - visibility-modifier-order', () => {
     const code = contractWith('function foo(address payable addr) public payable {}')
 
     const report = linter.processStr(code, {
-      rules: { 'visibility-modifier-order': 'error' }
+      rules: { 'visibility-modifier-order': 'error' },
     })
 
     assert.equal(report.errorCount, 0)

--- a/test/rules/security/avoid-call-value.js
+++ b/test/rules/security/avoid-call-value.js
@@ -1,13 +1,13 @@
 const assert = require('assert')
-const linter = require('./../../../lib/index')
-const funcWith = require('./../../common/contract-builder').funcWith
+const linter = require('../../../lib/index')
+const funcWith = require('../../common/contract-builder').funcWith
 
 describe('Linter - avoid-call-value', () => {
   it('should return "call.value" verification error', () => {
     const code = funcWith('x.call.value(55)();')
 
     const report = linter.processStr(code, {
-      rules: { 'avoid-call-value': 'error' }
+      rules: { 'avoid-call-value': 'error' },
     })
 
     assert.equal(report.errorCount, 1)

--- a/test/rules/security/avoid-low-level-calls.js
+++ b/test/rules/security/avoid-low-level-calls.js
@@ -1,14 +1,14 @@
-const linter = require('./../../../lib/index')
-const funcWith = require('./../../common/contract-builder').funcWith
-const { assertWarnsCount, assertErrorMessage } = require('./../../common/asserts')
+const linter = require('../../../lib/index')
+const funcWith = require('../../common/contract-builder').funcWith
+const { assertWarnsCount, assertErrorMessage } = require('../../common/asserts')
 
 describe('Linter - avoid-low-level-calls', () => {
   const LOW_LEVEL_CALLS = require('../../fixtures/security/low-level-calls').map(funcWith)
 
-  LOW_LEVEL_CALLS.forEach(curCode =>
+  LOW_LEVEL_CALLS.forEach((curCode) =>
     it('should return warn when code contains possible reentrancy', () => {
       const report = linter.processStr(curCode, {
-        rules: { 'avoid-low-level-calls': 'warn' }
+        rules: { 'avoid-low-level-calls': 'warn' },
       })
 
       assertWarnsCount(report, 1)

--- a/test/rules/security/avoid-sha3.js
+++ b/test/rules/security/avoid-sha3.js
@@ -1,16 +1,16 @@
 const assert = require('assert')
-const linter = require('./../../../lib/index')
-const funcWith = require('./../../common/contract-builder').funcWith
+const linter = require('../../../lib/index')
+const funcWith = require('../../common/contract-builder').funcWith
 
 describe('Linter - avoid-sha3', () => {
   const DEPRECATION_ERRORS = ['sha3("test");']
 
-  DEPRECATION_ERRORS.forEach(curText =>
+  DEPRECATION_ERRORS.forEach((curText) =>
     it(`should return error that used deprecations ${curText}`, () => {
       const code = funcWith(curText)
 
       const report = linter.processStr(code, {
-        rules: { 'avoid-sha3': 'error' }
+        rules: { 'avoid-sha3': 'error' },
       })
 
       assert.equal(report.errorCount, 1)
@@ -20,12 +20,12 @@ describe('Linter - avoid-sha3', () => {
 
   const ALMOST_DEPRECATION_ERRORS = ['sha33("test");']
 
-  ALMOST_DEPRECATION_ERRORS.forEach(curText =>
+  ALMOST_DEPRECATION_ERRORS.forEach((curText) =>
     it(`should not return error when doing ${curText}`, () => {
       const code = funcWith(curText)
 
       const report = linter.processStr(code, {
-        rules: { 'avoid-sha3': 'error' }
+        rules: { 'avoid-sha3': 'error' },
       })
 
       assert.equal(report.errorCount, 0)

--- a/test/rules/security/avoid-suicide.js
+++ b/test/rules/security/avoid-suicide.js
@@ -1,16 +1,16 @@
 const assert = require('assert')
-const linter = require('./../../../lib/index')
-const funcWith = require('./../../common/contract-builder').funcWith
+const linter = require('../../../lib/index')
+const funcWith = require('../../common/contract-builder').funcWith
 
 describe('Linter - avoid-suicide', () => {
   const DEPRECATION_ERRORS = ['suicide();']
 
-  DEPRECATION_ERRORS.forEach(curText =>
+  DEPRECATION_ERRORS.forEach((curText) =>
     it(`should return error that used deprecations ${curText}`, () => {
       const code = funcWith(curText)
 
       const report = linter.processStr(code, {
-        rules: { 'avoid-suicide': 'error' }
+        rules: { 'avoid-suicide': 'error' },
       })
 
       assert.equal(report.errorCount, 1)
@@ -20,12 +20,12 @@ describe('Linter - avoid-suicide', () => {
 
   const ALMOST_DEPRECATION_ERRORS = ['suicides();']
 
-  ALMOST_DEPRECATION_ERRORS.forEach(curText =>
+  ALMOST_DEPRECATION_ERRORS.forEach((curText) =>
     it(`should not return error when doing ${curText}`, () => {
       const code = funcWith(curText)
 
       const report = linter.processStr(code, {
-        rules: { 'avoid-suicide': 'error' }
+        rules: { 'avoid-suicide': 'error' },
       })
 
       assert.equal(report.errorCount, 0)

--- a/test/rules/security/avoid-throw.js
+++ b/test/rules/security/avoid-throw.js
@@ -1,16 +1,16 @@
 const assert = require('assert')
-const linter = require('./../../../lib/index')
-const funcWith = require('./../../common/contract-builder').funcWith
+const linter = require('../../../lib/index')
+const funcWith = require('../../common/contract-builder').funcWith
 
 describe('Linter - avoid-throw', () => {
   const DEPRECATION_ERRORS = ['throw;']
 
-  DEPRECATION_ERRORS.forEach(curText =>
+  DEPRECATION_ERRORS.forEach((curText) =>
     it(`should return error that used deprecations ${curText}`, () => {
       const code = funcWith(curText)
 
       const report = linter.processStr(code, {
-        rules: { 'avoid-throw': 'error' }
+        rules: { 'avoid-throw': 'error' },
       })
 
       assert.equal(report.errorCount, 1)
@@ -20,12 +20,12 @@ describe('Linter - avoid-throw', () => {
 
   const ALMOST_DEPRECATION_ERRORS = ['throwing;']
 
-  ALMOST_DEPRECATION_ERRORS.forEach(curText =>
+  ALMOST_DEPRECATION_ERRORS.forEach((curText) =>
     it(`should not return error when doing ${curText}`, () => {
       const code = funcWith(curText)
 
       const report = linter.processStr(code, {
-        rules: { 'avoid-throw': 'error' }
+        rules: { 'avoid-throw': 'error' },
       })
 
       assert.equal(report.errorCount, 0)

--- a/test/rules/security/avoid-tx-origin.js
+++ b/test/rules/security/avoid-tx-origin.js
@@ -1,7 +1,7 @@
 const assert = require('assert')
-const linter = require('./../../../lib/index')
-const funcWith = require('./../../common/contract-builder').funcWith
-const { assertErrorMessage } = require('./../../common/asserts')
+const linter = require('../../../lib/index')
+const funcWith = require('../../common/contract-builder').funcWith
+const { assertErrorMessage } = require('../../common/asserts')
 
 describe('Linter - avoid-tx-origin', () => {
   it('should return error that used tx.origin', () => {
@@ -10,7 +10,7 @@ describe('Linter - avoid-tx-origin', () => {
         `)
 
     const report = linter.processStr(code, {
-      rules: { 'avoid-tx-origin': 'error' }
+      rules: { 'avoid-tx-origin': 'error' },
     })
 
     assert.equal(report.errorCount, 1)

--- a/test/rules/security/check-send-result.js
+++ b/test/rules/security/check-send-result.js
@@ -1,13 +1,13 @@
 const assert = require('assert')
-const linter = require('./../../../lib/index')
-const funcWith = require('./../../common/contract-builder').funcWith
+const linter = require('../../../lib/index')
+const funcWith = require('../../common/contract-builder').funcWith
 
 describe('Linter - check-send-result', () => {
   it('should return "send" call verification error', () => {
     const code = funcWith(require('../../fixtures/security/send-result-ignored'))
 
     const report = linter.processStr(code, {
-      rules: { 'check-send-result': 'error' }
+      rules: { 'check-send-result': 'error' },
     })
 
     assert.equal(report.errorCount, 1)
@@ -18,7 +18,7 @@ describe('Linter - check-send-result', () => {
     const code = funcWith(require('../../fixtures/security/send-result-checked'))
 
     const report = linter.processStr(code, {
-      rules: { 'check-send-result': 'error' }
+      rules: { 'check-send-result': 'error' },
     })
 
     assert.equal(report.errorCount, 0)
@@ -28,7 +28,7 @@ describe('Linter - check-send-result', () => {
     const code = funcWith('require(x.send(1));')
 
     const report = linter.processStr(code, {
-      rules: { 'check-send-result': 'error' }
+      rules: { 'check-send-result': 'error' },
     })
 
     assert.equal(report.errorCount, 0)
@@ -38,7 +38,7 @@ describe('Linter - check-send-result', () => {
     const code = funcWith('require(!x.send(1));')
 
     const report = linter.processStr(code, {
-      rules: { 'check-send-result': 'error' }
+      rules: { 'check-send-result': 'error' },
     })
 
     assert.equal(report.errorCount, 0)
@@ -48,7 +48,7 @@ describe('Linter - check-send-result', () => {
     const code = funcWith('assert(x.send(1));')
 
     const report = linter.processStr(code, {
-      rules: { 'check-send-result': 'error' }
+      rules: { 'check-send-result': 'error' },
     })
 
     assert.equal(report.errorCount, 0)
@@ -58,7 +58,7 @@ describe('Linter - check-send-result', () => {
     const code = funcWith('assert(x.send(1) || something);')
 
     const report = linter.processStr(code, {
-      rules: { 'check-send-result': 'error' }
+      rules: { 'check-send-result': 'error' },
     })
 
     assert.equal(report.errorCount, 0)
@@ -68,7 +68,7 @@ describe('Linter - check-send-result', () => {
     const code = funcWith('f(x.send(1));')
 
     const report = linter.processStr(code, {
-      rules: { 'check-send-result': 'error' }
+      rules: { 'check-send-result': 'error' },
     })
 
     assert.equal(report.errorCount, 1)

--- a/test/rules/security/compiler-version.js
+++ b/test/rules/security/compiler-version.js
@@ -1,6 +1,6 @@
 const assert = require('assert')
-const { assertNoErrors, assertErrorCount, assertErrorMessage } = require('./../../common/asserts')
-const linter = require('./../../../lib/index')
+const { assertNoErrors, assertErrorCount, assertErrorMessage } = require('../../common/asserts')
+const linter = require('../../../lib/index')
 
 describe('Linter - compiler-version', () => {
   it('should disable only one compiler error on next line', () => {
@@ -11,7 +11,7 @@ describe('Linter - compiler-version', () => {
                 pragma solidity 0.3.4;
             `,
       {
-        rules: { 'compiler-version': ['error', '^0.5.2'] }
+        rules: { 'compiler-version': ['error', '^0.5.2'] },
       }
     )
 
@@ -26,7 +26,7 @@ describe('Linter - compiler-version', () => {
               pragma solidity 0.3.4;
           `,
       {
-        rules: { 'compiler-version': ['error', '^0.5.2'] }
+        rules: { 'compiler-version': ['error', '^0.5.2'] },
       }
     )
 
@@ -41,7 +41,7 @@ describe('Linter - compiler-version', () => {
                 pragma solidity 0.3.4;
             `,
       {
-        rules: { 'compiler-version': ['error', '^0.5.2'] }
+        rules: { 'compiler-version': ['error', '^0.5.2'] },
       }
     )
 
@@ -56,7 +56,7 @@ describe('Linter - compiler-version', () => {
                 pragma solidity 0.3.4;
             `,
       {
-        rules: { 'compiler-version': ['error', '^0.5.2'] }
+        rules: { 'compiler-version': ['error', '^0.5.2'] },
       }
     )
 
@@ -72,7 +72,7 @@ describe('Linter - compiler-version', () => {
                 pragma solidity 0.3.4;
             `,
       {
-        rules: { 'compiler-version': ['error', '^0.5.2'] }
+        rules: { 'compiler-version': ['error', '^0.5.2'] },
       }
     )
 
@@ -88,7 +88,7 @@ describe('Linter - compiler-version', () => {
                 pragma solidity 0.3.4;
             `,
       {
-        rules: { 'compiler-version': ['error', '^0.5.2'] }
+        rules: { 'compiler-version': ['error', '^0.5.2'] },
       }
     )
     assertNoErrors(report)
@@ -103,7 +103,7 @@ describe('Linter - compiler-version', () => {
                 pragma solidity ^0.4.4;
             `,
       {
-        rules: { 'compiler-version': ['error', '^0.5.2'] }
+        rules: { 'compiler-version': ['error', '^0.5.2'] },
       }
     )
 
@@ -113,7 +113,7 @@ describe('Linter - compiler-version', () => {
 
   it('should return compiler version error', () => {
     const report = linter.processStr('pragma solidity 0.3.4;', {
-      rules: { 'compiler-version': ['error', '^0.5.2'] }
+      rules: { 'compiler-version': ['error', '^0.5.2'] },
     })
 
     assert.equal(report.errorCount, 1)
@@ -122,7 +122,7 @@ describe('Linter - compiler-version', () => {
 
   it('should not report compiler version error on exact match', () => {
     const report = linter.processStr('pragma solidity 0.5.2;', {
-      rules: { 'compiler-version': ['error', '0.5.2'] }
+      rules: { 'compiler-version': ['error', '0.5.2'] },
     })
 
     assert.equal(report.errorCount, 0)
@@ -130,7 +130,7 @@ describe('Linter - compiler-version', () => {
 
   it('should not report compiler version error on range match', () => {
     const report = linter.processStr('pragma solidity ^0.5.2;', {
-      rules: { 'compiler-version': ['error', '^0.5.2'] }
+      rules: { 'compiler-version': ['error', '^0.5.2'] },
     })
 
     assert.equal(report.errorCount, 0)
@@ -138,7 +138,7 @@ describe('Linter - compiler-version', () => {
 
   it('should not report compiler version error on patch bump', () => {
     const report = linter.processStr('pragma solidity 0.5.3;', {
-      rules: { 'compiler-version': ['error', '^0.5.2'] }
+      rules: { 'compiler-version': ['error', '^0.5.2'] },
     })
 
     assert.equal(report.errorCount, 0)
@@ -146,7 +146,7 @@ describe('Linter - compiler-version', () => {
 
   it('should not report compiler version error on range match', () => {
     const report = linter.processStr('pragma solidity ^0.5.3;', {
-      rules: { 'compiler-version': ['error', '^0.5.2'] }
+      rules: { 'compiler-version': ['error', '^0.5.2'] },
     })
 
     assert.equal(report.errorCount, 0)
@@ -154,7 +154,7 @@ describe('Linter - compiler-version', () => {
 
   it('should report compiler version error on range not matching', () => {
     const report = linter.processStr('pragma solidity ^0.5.2;', {
-      rules: { 'compiler-version': ['error', '^0.5.3'] }
+      rules: { 'compiler-version': ['error', '^0.5.3'] },
     })
 
     assert.equal(report.errorCount, 1)
@@ -162,7 +162,7 @@ describe('Linter - compiler-version', () => {
 
   it('should report compiler version error on minor bump', () => {
     const report = linter.processStr('pragma solidity 0.6.0;', {
-      rules: { 'compiler-version': ['error', '^0.5.2'] }
+      rules: { 'compiler-version': ['error', '^0.5.2'] },
     })
 
     assert.equal(report.errorCount, 1)
@@ -170,7 +170,7 @@ describe('Linter - compiler-version', () => {
 
   it(`should report compiler version error if pragma doesn't exist`, () => {
     const report = linter.processStr('contract Foo {}', {
-      rules: { 'compiler-version': ['error', '^0.5.2'] }
+      rules: { 'compiler-version': ['error', '^0.5.2'] },
     })
 
     assert.equal(report.errorCount, 1)
@@ -181,7 +181,7 @@ describe('Linter - compiler-version', () => {
       `pragma solidity 0.6.0;
       contract Foo {}`,
       {
-        rules: { 'compiler-version': ['error', '^0.6.0'] }
+        rules: { 'compiler-version': ['error', '^0.6.0'] },
       }
     )
 
@@ -196,7 +196,7 @@ describe('Linter - compiler-version', () => {
        contract Main {
        }`,
       {
-        rules: { 'compiler-version': ['error', '^0.7.4'] }
+        rules: { 'compiler-version': ['error', '^0.7.4'] },
       }
     )
 

--- a/test/rules/security/func-visibility.js
+++ b/test/rules/security/func-visibility.js
@@ -1,14 +1,14 @@
 const assert = require('assert')
-const linter = require('./../../../lib/index')
-const contractWith = require('./../../common/contract-builder').contractWith
+const linter = require('../../../lib/index')
+const contractWith = require('../../common/contract-builder').contractWith
 
 describe('Linter - func-visibility', () => {
   it('should return required visibility error', () => {
-    require('../../fixtures/security/functions-without-visibility').forEach(func => {
+    require('../../fixtures/security/functions-without-visibility').forEach((func) => {
       const code = contractWith(func)
 
       const report = linter.processStr(code, {
-        rules: { 'func-visibility': 'warn' }
+        rules: { 'func-visibility': 'warn' },
       })
 
       assert.equal(report.warningCount, 1)
@@ -17,11 +17,11 @@ describe('Linter - func-visibility', () => {
   })
 
   it('should not return required visibility error', () => {
-    require('../../fixtures/security/functions-with-visibility').forEach(func => {
+    require('../../fixtures/security/functions-with-visibility').forEach((func) => {
       const code = contractWith(func)
 
       const report = linter.processStr(code, {
-        rules: { 'func-visibility': 'warn' }
+        rules: { 'func-visibility': 'warn' },
       })
 
       assert.equal(report.warningCount, 0)
@@ -34,8 +34,8 @@ describe('Linter - func-visibility', () => {
 
       const report = linter.processStr(code, {
         rules: {
-          'func-visibility': ['warn', { ignoreConstructors: true }]
-        }
+          'func-visibility': ['warn', { ignoreConstructors: true }],
+        },
       })
 
       assert.equal(report.warningCount, 0)
@@ -46,8 +46,8 @@ describe('Linter - func-visibility', () => {
 
       const report = linter.processStr(code, {
         rules: {
-          'func-visibility': ['warn', { ignoreConstructors: true }]
-        }
+          'func-visibility': ['warn', { ignoreConstructors: true }],
+        },
       })
 
       assert.equal(report.warningCount, 1)

--- a/test/rules/security/mark-callable-contracts.js
+++ b/test/rules/security/mark-callable-contracts.js
@@ -4,7 +4,7 @@ const { funcWith, contractWith } = require('../../common/contract-builder')
 
 describe('Linter - mark-callable-contracts', () => {
   it('should return error that external contract is not marked as trusted / untrusted', () => {
-    const code = funcWith(require('../../fixtures/security/external-contract-untrusted.js'))
+    const code = funcWith(require('../../fixtures/security/external-contract-untrusted'))
 
     const report = linter.processStr(code, {
       rules: { 'mark-callable-contracts': 'warn' },
@@ -15,7 +15,7 @@ describe('Linter - mark-callable-contracts', () => {
   })
 
   it('should not return error for external contract that is marked as trusted', () => {
-    const code = funcWith(require('../../fixtures/security/external-contract-trusted.js'))
+    const code = funcWith(require('../../fixtures/security/external-contract-trusted'))
 
     const report = linter.processStr(code, {
       rules: { 'mark-callable-contracts': 'warn' },

--- a/test/rules/security/mark-callable-contracts.js
+++ b/test/rules/security/mark-callable-contracts.js
@@ -1,13 +1,13 @@
 const assert = require('assert')
-const linter = require('./../../../lib/index')
-const { funcWith, contractWith } = require('./../../common/contract-builder')
+const linter = require('../../../lib/index')
+const { funcWith, contractWith } = require('../../common/contract-builder')
 
 describe('Linter - mark-callable-contracts', () => {
   it('should return error that external contract is not marked as trusted / untrusted', () => {
     const code = funcWith(require('../../fixtures/security/external-contract-untrusted.js'))
 
     const report = linter.processStr(code, {
-      rules: { 'mark-callable-contracts': 'warn' }
+      rules: { 'mark-callable-contracts': 'warn' },
     })
 
     assert.equal(report.warningCount, 1)
@@ -18,7 +18,7 @@ describe('Linter - mark-callable-contracts', () => {
     const code = funcWith(require('../../fixtures/security/external-contract-trusted.js'))
 
     const report = linter.processStr(code, {
-      rules: { 'mark-callable-contracts': 'warn' }
+      rules: { 'mark-callable-contracts': 'warn' },
     })
 
     assert.equal(report.warningCount, 0)
@@ -28,7 +28,7 @@ describe('Linter - mark-callable-contracts', () => {
     const code = funcWith('UntrustedBank.withdraw(100);')
 
     const report = linter.processStr(code, {
-      rules: { 'mark-callable-contracts': 'warn' }
+      rules: { 'mark-callable-contracts': 'warn' },
     })
 
     assert.equal(report.warningCount, 0)
@@ -50,7 +50,7 @@ describe('Linter - mark-callable-contracts', () => {
     `)
 
     const report = linter.processStr(code, {
-      rules: { 'mark-callable-contracts': 'warn' }
+      rules: { 'mark-callable-contracts': 'warn' },
     })
 
     assert.equal(report.warningCount, 0)
@@ -66,7 +66,7 @@ describe('Linter - mark-callable-contracts', () => {
     `)
 
     const report = linter.processStr(code, {
-      rules: { 'mark-callable-contracts': 'warn' }
+      rules: { 'mark-callable-contracts': 'warn' },
     })
 
     assert.equal(report.warningCount, 0)
@@ -82,7 +82,7 @@ describe('Linter - mark-callable-contracts', () => {
     `)
 
     const report = linter.processStr(code, {
-      rules: { 'mark-callable-contracts': 'warn' }
+      rules: { 'mark-callable-contracts': 'warn' },
     })
 
     assert.equal(report.warningCount, 0)
@@ -98,7 +98,7 @@ describe('Linter - mark-callable-contracts', () => {
     `)
 
     const report = linter.processStr(code, {
-      rules: { 'mark-callable-contracts': 'warn' }
+      rules: { 'mark-callable-contracts': 'warn' },
     })
 
     assert.equal(report.warningCount, 0)
@@ -114,7 +114,7 @@ describe('Linter - mark-callable-contracts', () => {
     `)
 
     const report = linter.processStr(code, {
-      rules: { 'mark-callable-contracts': 'warn' }
+      rules: { 'mark-callable-contracts': 'warn' },
     })
 
     assert.equal(report.warningCount, 0)
@@ -129,7 +129,7 @@ describe('Linter - mark-callable-contracts', () => {
     `)
 
     const report = linter.processStr(code, {
-      rules: { 'mark-callable-contracts': 'warn' }
+      rules: { 'mark-callable-contracts': 'warn' },
     })
 
     assert.equal(report.warningCount, 0)

--- a/test/rules/security/multiple-sends.js
+++ b/test/rules/security/multiple-sends.js
@@ -1,7 +1,7 @@
 const assert = require('assert')
-const linter = require('./../../../lib/index')
-const funcWith = require('./../../common/contract-builder').funcWith
-const { assertErrorMessage, assertErrorCount } = require('./../../common/asserts')
+const linter = require('../../../lib/index')
+const funcWith = require('../../common/contract-builder').funcWith
+const { assertErrorMessage, assertErrorCount } = require('../../common/asserts')
 
 describe('Linter - multiple-sends', () => {
   it('should return the error that multiple send calls are being used in the same transaction', () => {
@@ -11,7 +11,7 @@ describe('Linter - multiple-sends', () => {
         `)
 
     const report = linter.processStr(code, {
-      rules: { 'multiple-sends': 'error' }
+      rules: { 'multiple-sends': 'error' },
     })
 
     assert.equal(report.errorCount, 1)
@@ -24,7 +24,7 @@ describe('Linter - multiple-sends', () => {
         `)
 
     const report = linter.processStr(code, {
-      rules: { 'multiple-sends': 'error' }
+      rules: { 'multiple-sends': 'error' },
     })
 
     assertErrorCount(report, 1)

--- a/test/rules/security/no-complex-fallback.js
+++ b/test/rules/security/no-complex-fallback.js
@@ -1,6 +1,6 @@
 const assert = require('assert')
-const linter = require('./../../../lib/index')
-const contractWith = require('./../../common/contract-builder').contractWith
+const linter = require('../../../lib/index')
+const contractWith = require('../../common/contract-builder').contractWith
 
 describe('Linter - no-complex-fallback', () => {
   it('should return that fallback must be simple', () => {
@@ -10,7 +10,7 @@ describe('Linter - no-complex-fallback', () => {
         }`)
 
     const report = linter.processStr(code, {
-      rules: { 'no-complex-fallback': 'warn' }
+      rules: { 'no-complex-fallback': 'warn' },
     })
 
     assert.equal(report.warningCount, 1)

--- a/test/rules/security/no-inline-assembly.js
+++ b/test/rules/security/no-inline-assembly.js
@@ -1,13 +1,13 @@
-const linter = require('./../../../lib/index')
-const funcWith = require('./../../common/contract-builder').funcWith
-const { assertWarnsCount, assertErrorMessage } = require('./../../common/asserts')
+const linter = require('../../../lib/index')
+const funcWith = require('../../common/contract-builder').funcWith
+const { assertWarnsCount, assertErrorMessage } = require('../../common/asserts')
 
 describe('Linter - no-inline-assembly', () => {
   it('should return warn when function use inline assembly', () => {
     const code = funcWith(' assembly { "test" } ')
 
     const report = linter.processStr(code, {
-      rules: { 'no-inline-assembly': 'warn' }
+      rules: { 'no-inline-assembly': 'warn' },
     })
 
     assertWarnsCount(report, 1)

--- a/test/rules/security/not-rely-on-block-hash.js
+++ b/test/rules/security/not-rely-on-block-hash.js
@@ -1,13 +1,13 @@
-const linter = require('./../../../lib/index')
-const funcWith = require('./../../common/contract-builder').funcWith
-const { assertWarnsCount, assertErrorMessage } = require('./../../common/asserts')
+const linter = require('../../../lib/index')
+const funcWith = require('../../common/contract-builder').funcWith
+const { assertWarnsCount, assertErrorMessage } = require('../../common/asserts')
 
 describe('Linter - not-rely-on-block-hash', () => {
   it('should return warn when function rely on block has', () => {
     const code = funcWith('end >= block.blockhash + daysAfter * 1 days;')
 
     const report = linter.processStr(code, {
-      rules: { 'not-rely-on-block-hash': 'warn' }
+      rules: { 'not-rely-on-block-hash': 'warn' },
     })
 
     assertWarnsCount(report, 1)

--- a/test/rules/security/not-rely-on-time.js
+++ b/test/rules/security/not-rely-on-time.js
@@ -1,17 +1,17 @@
-const linter = require('./../../../lib/index')
-const funcWith = require('./../../common/contract-builder').funcWith
-const { assertWarnsCount, assertErrorMessage } = require('./../../common/asserts')
+const linter = require('../../../lib/index')
+const funcWith = require('../../common/contract-builder').funcWith
+const { assertWarnsCount, assertErrorMessage } = require('../../common/asserts')
 
 describe('Linter - not-rely-on-time', () => {
   const TIME_BASED_LOGIC = [
     funcWith('now >= start + daysAfter * 1 days;'),
-    funcWith('start >= block.timestamp + daysAfter * 1 days;')
+    funcWith('start >= block.timestamp + daysAfter * 1 days;'),
   ]
 
-  TIME_BASED_LOGIC.forEach(curCode =>
+  TIME_BASED_LOGIC.forEach((curCode) =>
     it('should return warn when business logic rely on time', () => {
       const report = linter.processStr(curCode, {
-        rules: { 'not-rely-on-time': 'warn' }
+        rules: { 'not-rely-on-time': 'warn' },
       })
 
       assertWarnsCount(report, 1)

--- a/test/rules/security/reentrancy.js
+++ b/test/rules/security/reentrancy.js
@@ -1,11 +1,11 @@
-const linter = require('./../../../lib/index')
-const { assertWarnsCount, assertErrorMessage, assertNoWarnings } = require('./../../common/asserts')
+const linter = require('../../../lib/index')
+const { assertWarnsCount, assertErrorMessage, assertNoWarnings } = require('../../common/asserts')
 
 describe('Linter - reentrancy', () => {
-  require('../../fixtures/security/reentrancy-vulenarble').forEach(curCode =>
+  require('../../fixtures/security/reentrancy-vulenarble').forEach((curCode) =>
     it('should return warn when code contains possible reentrancy', () => {
       const report = linter.processStr(curCode, {
-        rules: { reentrancy: 'warn' }
+        rules: { reentrancy: 'warn' },
       })
 
       assertWarnsCount(report, 1)
@@ -13,10 +13,10 @@ describe('Linter - reentrancy', () => {
     })
   )
 
-  require('../../fixtures/security/reentrancy-invulenarble').forEach(curCode =>
+  require('../../fixtures/security/reentrancy-invulenarble').forEach((curCode) =>
     it('should not return warn when code do not contains transfer', () => {
       const report = linter.processStr(curCode, {
-        rules: { reentrancy: 'warn' }
+        rules: { reentrancy: 'warn' },
       })
 
       assertNoWarnings(report)

--- a/test/rules/security/state-visibility.js
+++ b/test/rules/security/state-visibility.js
@@ -1,13 +1,13 @@
 const assert = require('assert')
-const linter = require('./../../../lib/index')
-const contractWith = require('./../../common/contract-builder').contractWith
+const linter = require('../../../lib/index')
+const contractWith = require('../../common/contract-builder').contractWith
 
 describe('Linter - state-visibility', () => {
   it('should return required visibility error for state', () => {
     const code = contractWith('uint a;')
 
     const report = linter.processStr(code, {
-      rules: { 'state-visibility': 'warn' }
+      rules: { 'state-visibility': 'warn' },
     })
 
     assert.equal(report.warningCount, 1)
@@ -17,13 +17,13 @@ describe('Linter - state-visibility', () => {
   const BLOCKS_WITH_DEFINITIONS = [
     contractWith('uint private a;'),
     contractWith('uint public a;'),
-    contractWith('uint internal a;')
+    contractWith('uint internal a;'),
   ]
 
-  BLOCKS_WITH_DEFINITIONS.forEach(curData =>
+  BLOCKS_WITH_DEFINITIONS.forEach((curData) =>
     it(`should not raise warn for blocks ${label(curData)}`, () => {
       const report = linter.processStr(curData, {
-        rules: { 'state-visibility': 'warn' }
+        rules: { 'state-visibility': 'warn' },
       })
 
       assert.equal(report.warningCount, 0)


### PR DESCRIPTION
Please consider configuring github merge to do a linear/semi-linear history on merge preserving history so:

- when reading a blame/log, automated linter changes can be told apart from ones made by hoomans
- contributor credit is registered in git history as well as github repository