### PR TITLE
Fix doc generation

### DIFF
--- a/.github/workflows/E2E.yml
+++ b/.github/workflows/E2E.yml
@@ -20,10 +20,14 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - uses: actions/checkout@v2
+      - name: install
+        run: npm install --include=dev
+      - name: lint
+        run: npm run lint
+      - name: generate-docs
+        run: npm run docs 
       - name: pack
         run: npm pack
-      - name: lint
-        run: npm install && npm run lint
       - name: install-globally
         run: npm i -g solhint*tgz
       - name: run-e2e-tests

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -4,7 +4,7 @@ layout:      "default"
 title:       "Rule Index of Solhint"
 ---
 
-## Best Practice Rules
+## Best Practise Rules
 
 | Rule Id                                                            | Error                                                                                                                 | Recommended |
 | ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------- | ----------- |
@@ -12,6 +12,7 @@ title:       "Rule Index of Solhint"
 | [function-max-lines](./rules/best-practises/function-max-lines.md) | Function body contains "count" lines but allowed no more than maxlines.                                               |             |
 | [max-line-length](./rules/best-practises/max-line-length.md)       | Line length must be no more than maxlen.                                                                              |             |
 | [max-states-count](./rules/best-practises/max-states-count.md)     | Contract has "some count" states declarations but allowed no more than maxstates.                                     | ✔️          |
+| [no-console](./rules/best-practises/no-console.md)                 | No console.log/logInt/logBytesX/logString/etc & No hardhat and forge-std console.sol import statements                | ✔️          |
 | [no-empty-blocks](./rules/best-practises/no-empty-blocks.md)       | Code contains empty block.                                                                                            | ✔️          |
 | [no-unused-vars](./rules/best-practises/no-unused-vars.md)         | Variable "name" is unused.                                                                                            | ✔️          |
 | [payable-fallback](./rules/best-practises/payable-fallback.md)     | When fallback is not payable you will not be able to receive ethers.                                                  | ✔️          |
@@ -34,7 +35,7 @@ title:       "Rule Index of Solhint"
 | [const-name-snakecase](./rules/naming/const-name-snakecase.md)                       | Constant name must be in capitalized SNAKE_CASE.                                       | ✔️          |
 | [contract-name-camelcase](./rules/naming/contract-name-camelcase.md)                 | Contract name must be in CamelCase.                                                    | ✔️          |
 | [event-name-camelcase](./rules/naming/event-name-camelcase.md)                       | Event name must be in CamelCase.                                                       | ✔️          |
-| [func-name-mixedcase](./rules/naming/func-name-mixedcase.md)                         | Function name must be in camelCase.                                                    | ✔️          |
+| [func-name-mixedcase](./rules/naming/func-name-mixedcase.md)                         | Function name must be in mixedCase.                                                    | ✔️          |
 | [func-param-name-mixedcase](./rules/naming/func-param-name-mixedcase.md)             | Function param name must be in mixedCase                                               |             |
 | [modifier-name-mixedcase](./rules/naming/modifier-name-mixedcase.md)                 | Modifier name must be in mixedCase.                                                    |             |
 | [private-vars-leading-underscore](./rules/naming/private-vars-leading-underscore.md) | Private and internal names must start with a single underscore.                        |             |
@@ -64,7 +65,7 @@ title:       "Rule Index of Solhint"
 | [no-complex-fallback](./rules/security/no-complex-fallback.md)         | Fallback function must be simple.                                        | ✔️          |
 | [no-inline-assembly](./rules/security/no-inline-assembly.md)           | Avoid to use inline assembly. It is acceptable only in rare cases.       | ✔️          |
 | [not-rely-on-block-hash](./rules/security/not-rely-on-block-hash.md)   | Do not rely on "block.blockhash". Miners can influence its value.        | ✔️          |
-| [not-rely-on-time](./rules/security/not-rely-on-time.md)               | Avoid making time-based decisions in your business logic.               | ✔️          |
+| [not-rely-on-time](./rules/security/not-rely-on-time.md)               | Avoid making time-based decisions in your business logic.                | ✔️          |
 | [reentrancy](./rules/security/reentrancy.md)                           | Possible reentrancy vulnerabilities. Avoid state changes after transfer. | ✔️          |
 | [state-visibility](./rules/security/state-visibility.md)               | Explicitly mark visibility of state.                                     | ✔️          |
         

--- a/docs/rules/best-practises/no-console.md
+++ b/docs/rules/best-practises/no-console.md
@@ -1,0 +1,59 @@
+---
+warning:     "This is a dynamically generated file. Do not edit manually."
+layout:      "default"
+title:       "no-console | Solhint"
+---
+
+# no-console
+![Recommended Badge](https://img.shields.io/badge/-Recommended-brightgreen)
+![Category Badge](https://img.shields.io/badge/-Best%20Practise%20Rules-informational)
+![Default Severity Badge error](https://img.shields.io/badge/Default%20Severity-error-red)
+> The {"extends": "solhint:default"} property in a configuration file enables this rule.
+
+> The {"extends": "solhint:recommended"} property in a configuration file enables this rule.
+
+
+## Description
+No console.log/logInt/logBytesX/logString/etc & No hardhat and forge-std console.sol import statements
+
+## Options
+This rule accepts a string option of rule severity. Must be one of "error", "warn", "off". Default to error.
+
+### Example Config
+```json
+{
+  "rules": {
+    "no-console": "error"
+  }
+}
+```
+
+
+## Examples
+### 👎 Examples of **incorrect** code for this rule
+
+#### No console.logX statements
+
+```solidity
+console.log('test')
+```
+
+#### No hardhat/console.sol import statements
+
+```solidity
+import "hardhat/console.sol"
+```
+
+#### No forge-std console.sol & console2.sol import statements
+
+```solidity
+import "forge-std/consoleN.sol"
+```
+
+## Version
+This rule is introduced in the latest version.
+
+## Resources
+- [Rule source](https://github.com/protofire/solhint/tree/master/lib/rules/best-practises/no-console.js)
+- [Document source](https://github.com/protofire/solhint/tree/master/docs/rules/best-practises/no-console.md)
+- [Test cases](https://github.com/protofire/solhint/tree/master/test/rules/best-practises/no-console.js)

--- a/docs/rules/miscellaneous/comprehensive-interface.md
+++ b/docs/rules/miscellaneous/comprehensive-interface.md
@@ -9,7 +9,7 @@ title:       "comprehensive-interface | Solhint"
 ![Default Severity Badge warn](https://img.shields.io/badge/Default%20Severity-warn-yellow)
 
 ## Description
-Check that all public or external functions are override. This is useful to make sure that the whole API is extracted in an interface.
+Check that all public or external functions are override. This is iseful to make sure that the whole API is extracted in an interface.
 
 ## Options
 This rule accepts a string option of rule severity. Must be one of "error", "warn", "off". Default to warn.

--- a/docs/rules/naming/func-name-mixedcase.md
+++ b/docs/rules/naming/func-name-mixedcase.md
@@ -12,7 +12,7 @@ title:       "func-name-mixedcase | Solhint"
 
 
 ## Description
-Function name must be in camelCase.
+Function name must be in mixedCase.
 
 ## Options
 This rule accepts a string option of rule severity. Must be one of "error", "warn", "off". Default to warn.

--- a/docs/rules/order/ordering.md
+++ b/docs/rules/order/ordering.md
@@ -27,79 +27,220 @@ This rule accepts a string option of rule severity. Must be one of "error", "war
 ## Examples
 ### 👍 Examples of **correct** code for this rule
 
-#### All units are in order
+#### All units are in order - ^0.4.0
 
 ```solidity
+
+pragma solidity ^0.4.0;
+
+import "./some/library.sol";
+import "./some/other-library.sol";
+
+enum MyEnum {
+  Foo,
+  Bar
+}
+
+struct MyStruct {
+  uint x;
+  uint y;
+}
+
+interface IBox {
+  function getValue() public;
+  function setValue(uint) public;
+}
+
+library MyLibrary {
+  function add(uint a, uint b, uint c) public returns (uint) {
+    return a + b + c;
+  }
+}
+
+contract MyContract {
+  struct InnerStruct {
+    bool flag;
+  }
+
+  enum InnerEnum {
+    A, B, C
+  }
+
+  uint public x;
+  uint public y;
+
+  event MyEvent(address a);
+
+  constructor () public {}
+
+  fallback () external {}
+
+  function myExternalFunction() external {}
+  function myExternalConstantFunction() external constant {}
+
+  function myPublicFunction() public {}
+  function myPublicConstantFunction() public constant {}
+
+  function myInternalFunction() internal {}
+  function myPrivateFunction() private {}
+}
+
+```
+
+#### All units are in order - ^0.5.0
+
+```solidity
+
+pragma solidity ^0.5.0;
+
+import "./some/library.sol";
+import "./some/other-library.sol";
+
+enum MyEnum {
+  Foo,
+  Bar
+}
+
+struct MyStruct {
+  uint x;
+  uint y;
+}
+
+interface IBox {
+  function getValue() public;
+  function setValue(uint) public;
+}
+
+library MyLibrary {
+  function add(uint a, uint b, uint c) public returns (uint) {
+    return a + b + c;
+  }
+}
+
+contract MyContract {
+  using MyLibrary for uint;
+
+  struct InnerStruct {
+    bool flag;
+  }
+
+  enum InnerEnum {
+    A, B, C
+  }
+
+  address payable owner;
+  uint public x;
+  uint public y;
+
+  event MyEvent(address a);
+
+  modifier onlyOwner {
+    require(
+      msg.sender == owner,
+      "Only owner can call this function."
+    );
+    _;
+  }
+
+  constructor () public {}
+
+  fallback () external {}
+
+  function myExternalFunction() external {}
+  function myExternalViewFunction() external view {}
+  function myExternalPureFunction() external pure {}
+
+  function myPublicFunction() public {}
+  function myPublicViewFunction() public view {}
+  function myPublicPureFunction() public pure {}
+
+  function myInternalFunction() internal {}
+  function myInternalViewFunction() internal view {}
+  function myInternalPureFunction() internal pure {}
+
+  function myPrivateFunction() private {}
+  function myPrivateViewFunction() private view {}
+  function myPrivatePureFunction() private pure {}
+}
+
+```
+
+#### All units are in order - ^0.6.0
+
+```solidity
+
 pragma solidity ^0.6.0;
 
 import "./some/library.sol";
 import "./some/other-library.sol";
 
-    enum MyEnum {
-        Foo,
-        Bar
-    }
+enum MyEnum {
+  Foo,
+  Bar
+}
 
-    struct MyStruct {
-        uint x;
-        uint y;
-    }
+struct MyStruct {
+  uint x;
+  uint y;
+}
 
 interface IBox {
-    function getValue() public;
-    function setValue(uint) public;
+  function getValue() public;
+  function setValue(uint) public;
 }
 
 library MyLibrary {
-    function add(uint a, uint b, uint c) public returns (uint) {
-        return a + b + c;
-    }
+  function add(uint a, uint b, uint c) public returns (uint) {
+    return a + b + c;
+  }
 }
 
 contract MyContract {
-    using MyLibrary for uint;
+  using MyLibrary for uint;
 
-    struct InnerStruct {
-        bool flag;
-    }
+  struct InnerStruct {
+    bool flag;
+  }
 
-    enum InnerEnum {
-        A, B, C
-    }
+  enum InnerEnum {
+    A, B, C
+  }
 
-    address payable owner;
-    uint public x;
-    uint public y;
+  address payable owner;
+  uint public x;
+  uint public y;
 
-    event MyEvent(address a);
+  event MyEvent(address a);
 
-    modifier onlyOwner {
-        require(
-            msg.sender == owner,
-            "Only owner can call this function."
-        );
-        _;
-    }
+  modifier onlyOwner {
+    require(
+      msg.sender == owner,
+      "Only owner can call this function."
+    );
+    _;
+  }
 
-    constructor () public {}
+  constructor () public {}
 
-    fallback () external {}
+  receive() external payable {}
 
-    function myExternalFunction() external {}
-    function myExternalViewFunction() external view {}
-    function myExternalPureFunction() external pure {}
+  fallback () external {}
 
-    function myPublicFunction() public {}
-    function myPublicViewFunction() public view {}
-    function myPublicPureFunction() public pure {}
+  function myExternalFunction() external {}
+  function myExternalViewFunction() external view {}
+  function myExternalPureFunction() external pure {}
 
-    function myInternalFunction() internal {}
-    function myInternalViewFunction() internal view {}
-    function myInternalPureFunction() internal pure {}
+  function myPublicFunction() public {}
+  function myPublicViewFunction() public view {}
+  function myPublicPureFunction() public pure {}
 
-    function myPrivateFunction() private {}
-    function myPrivateViewFunction() private view {}
-    function myPrivatePureFunction() private pure {}
+  function myInternalFunction() internal {}
+  function myInternalViewFunction() internal view {}
+  function myInternalPureFunction() internal pure {}
+
+  function myPrivateFunction() private {}
+  function myPrivateViewFunction() private view {}
+  function myPrivatePureFunction() private pure {}
 }
 
 ```
@@ -135,6 +276,66 @@ contract MyContract {
   library MyLibrary {}
 
   interface MyInterface {}
+
+```
+
+#### Use for after state variable
+
+```solidity
+
+contract MyContract {
+  uint public x;
+  
+  using MyMathLib for uint;
+}
+
+```
+
+#### External pure before external view
+
+```solidity
+
+contract MyContract {
+  function myExternalFunction() external {}
+  function myExternalPureFunction() external pure {}
+  function myExternalViewFunction() external view {}
+}
+
+```
+
+#### Public pure before public view
+
+```solidity
+
+contract MyContract {
+  function myPublicFunction() public {}
+  function myPublicPureFunction() public pure {}
+  function myPublicViewFunction() public view {}
+}
+
+```
+
+#### Internal pure before internal view
+
+```solidity
+
+contract MyContract {
+  function myInternalFunction() internal {}
+  function myInternalPureFunction() internal pure {}
+  function myInternalViewFunction() internal view {}
+}
+
+```
+
+#### Private pure before private view
+
+```solidity
+
+contract MyContract {
+  function myPrivateFunction() private {}
+  function myPrivatePureFunction() private pure {}
+  function myPrivateViewFunction() private view {}
+}
 
 ```
 

--- a/lib/rules/best-practises/no-console.js
+++ b/lib/rules/best-practises/no-console.js
@@ -1,7 +1,5 @@
 const BaseChecker = require('../base-checker')
 
-const DEFAULT_SEVERITY = 'error'
-
 const ruleId = 'no-console'
 const meta = {
   type: 'best-practises',
@@ -29,7 +27,7 @@ const meta = {
 
   isDefault: true,
   recommended: true,
-  defaultSetup: [DEFAULT_SEVERITY],
+  defaultSetup: 'error',
   schema: null,
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "solhint",
-  "version": "3.3.7",
+  "version": "3.3.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "solhint",
-      "version": "3.3.7",
+      "version": "3.3.8",
       "license": "MIT",
       "dependencies": {
         "@solidity-parser/parser": "^0.14.5",
@@ -38,7 +38,7 @@
         "eslint-config-prettier": "^8.6.0",
         "eslint-plugin-import": "^2.27.4",
         "eslint-plugin-prettier": "^4.2.1",
-        "markdown-table": "^3.0.3",
+        "markdown-table": "^2.0.0",
         "mocha": "^10.2.0",
         "mocha-lcov-reporter": "^1.3.0",
         "nyc": "^15.1.0",
@@ -3215,10 +3215,13 @@
       }
     },
     "node_modules/markdown-table": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.3.tgz",
-      "integrity": "sha512-Z1NL3Tb1M9wH4XESsCDEksWoKTdlUafKc4pt0GRwjUyXaCFZ+dc3g2erqB6zm3szA2IUSi7VnPI+o/9jnxh9hw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
+      "integrity": "sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==",
       "dev": true,
+      "dependencies": {
+        "repeat-string": "^1.0.0"
+      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -4139,6 +4142,15 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/request": {
@@ -7444,10 +7456,13 @@
       }
     },
     "markdown-table": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.3.tgz",
-      "integrity": "sha512-Z1NL3Tb1M9wH4XESsCDEksWoKTdlUafKc4pt0GRwjUyXaCFZ+dc3g2erqB6zm3szA2IUSi7VnPI+o/9jnxh9hw==",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
+      "integrity": "sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==",
+      "dev": true,
+      "requires": {
+        "repeat-string": "^1.0.0"
+      }
     },
     "mime-db": {
       "version": "1.52.0",
@@ -8119,6 +8134,12 @@
       "requires": {
         "es6-error": "^4.0.1"
       }
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
+      "dev": true
     },
     "request": {
       "version": "2.88.2",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "eslint-config-prettier": "^8.6.0",
     "eslint-plugin-import": "^2.27.4",
     "eslint-plugin-prettier": "^4.2.1",
-    "markdown-table": "^3.0.3",
+    "markdown-table": "^2.0.0",
     "mocha": "^10.2.0",
     "mocha-lcov-reporter": "^1.3.0",
     "nyc": "^15.1.0",


### PR DESCRIPTION
while creating a new rule I found that the script responsible for generating the documentation was broken (well, not the script itself, but the metadata supplied to it) I fixed it and added a CI step to ensure that at least it doesn't crash.

I tried to get CI to also check that the latest version of the docs are commited to source control (with `git diff docs --exit-code`) but versions for files were different between CI and my machine. So it's out of scope for this PR :upside_down_face: but I can create an issue to implement that later if there's consensus