### PR TITLE
fix: no-console rule update

### DIFF
--- a/lib/rules/best-practises/no-console.js
+++ b/lib/rules/best-practises/no-console.js
@@ -17,11 +17,11 @@ const meta = {
         },
         {
           description: 'No hardhat/console.sol import statements',
-          code: 'import "hardhat/console.sol"' // eslint-disable-line
+          code: 'import "hardhat/console.sol"', // eslint-disable-line
         },
         {
           description: 'No forge-std console.sol & console2.sol import statements',
-          code: 'import "forge-std/consoleN.sol"' // eslint-disable-line
+          code: 'import "forge-std/consoleN.sol"', // eslint-disable-line
         },
       ],
     },
@@ -41,24 +41,31 @@ class NoConsoleLogChecker extends BaseChecker {
   ImportDirective(node) {
     this.isAnImport(node)
     if (this.isAnImport(node)) {
-      this.error(node, 'No import "hardhat/console.sol" or "forge-std/console.sol" statements') // eslint-disable-line
+      this.error(node, 'Unexpected import of console file')
     }
   }
 
   FunctionCall(node) {
     if (this.isConsoleLog(node)) {
-      this.error(node, 'No console.logX or console2.log statements')
+      this.error(node, 'Unexpected console statement')
     }
   }
 
   isConsoleLog(node) {
-    return node.expression.expression.name.includes('console')
+    return (
+      node.expression.expression.type === 'Identifier' &&
+      (node.expression.expression.name === 'console' ||
+        node.expression.expression.name === 'console2') &&
+      node.expression.memberName.startsWith('log')
+    )
   }
 
   isAnImport(node) {
     return (
       node.type === 'ImportDirective' &&
-      (node.path === 'hardhat/console.sol' || node.path.includes('forge-std/console'))
+      (node.path === 'hardhat/console.sol' ||
+        node.path === 'forge-std/console.sol' ||
+        node.path === 'forge-std/console2.sol')
     )
   }
 }

--- a/lib/rules/best-practises/no-console.js
+++ b/lib/rules/best-practises/no-console.js
@@ -17,11 +17,11 @@ const meta = {
         },
         {
           description: 'No hardhat/console.sol import statements',
-          code: 'import "hardhat/console.sol"', // eslint-disable-line
+          code: 'import "hardhat/console.sol"',
         },
         {
           description: 'No forge-std console.sol & console2.sol import statements',
-          code: 'import "forge-std/consoleN.sol"', // eslint-disable-line
+          code: 'import "forge-std/consoleN.sol"',
         },
       ],
     },
@@ -39,7 +39,6 @@ class NoConsoleLogChecker extends BaseChecker {
   }
 
   ImportDirective(node) {
-    this.isAnImport(node)
     if (this.isAnImport(node)) {
       this.error(node, 'Unexpected import of console file')
     }

--- a/lib/rules/best-practises/no-console.js
+++ b/lib/rules/best-practises/no-console.js
@@ -39,7 +39,7 @@ class NoConsoleLogChecker extends BaseChecker {
   }
 
   ImportDirective(node) {
-    if (this.isAnImport(node)) {
+    if (this.isConsoleImport(node)) {
       this.error(node, 'Unexpected import of console file')
     }
   }
@@ -59,12 +59,11 @@ class NoConsoleLogChecker extends BaseChecker {
     )
   }
 
-  isAnImport(node) {
+  isConsoleImport(node) {
     return (
-      node.type === 'ImportDirective' &&
-      (node.path === 'hardhat/console.sol' ||
-        node.path === 'forge-std/console.sol' ||
-        node.path === 'forge-std/console2.sol')
+      node.path === 'hardhat/console.sol' ||
+      node.path === 'forge-std/console.sol' ||
+      node.path === 'forge-std/console2.sol'
     )
   }
 }

--- a/test/rules/best-practises/no-console.js
+++ b/test/rules/best-practises/no-console.js
@@ -3,8 +3,8 @@ const linter = require('../../../lib/index')
 const { assertErrorMessage } = require('../../common/asserts')
 const { funcWith } = require('../../common/contract-builder')
 
-const FUNCTION_CALL_ERROR = 'No console.logX or console2.log statements'
-const IMPORT_ERROR = 'No import "hardhat/console.sol" or "forge-std/console.sol" statements'
+const FUNCTION_CALL_ERROR = 'Unexpected console statement'
+const IMPORT_ERROR = 'Unexpected import of console file'
 
 describe('Linter - no-console', () => {
   it('should raise console.log() is not allowed', () => {
@@ -105,6 +105,29 @@ describe('Linter - no-console', () => {
     const code = `
     import "forge-std/xxxxx.sol";
     contract A {}
+    `
+
+    const report = linter.processStr(code, {
+      rules: { 'no-console': ['error'] },
+    })
+
+    assert.equal(report.errorCount, 0)
+  })
+
+  it('should NOT raise error when method invocation contains "console" string', () => {
+    const code = `
+    contract A {
+      struct Console {
+        uint256 one;
+        uint256 two;
+      }
+      Console[] public consoleTest;
+      Console[] public console;
+      function niceFunction() external {
+        consoleTest.push(0,0);
+        console.push = (1,1);
+      }
+    }
     `
 
     const report = linter.processStr(code, {


### PR DESCRIPTION
There was an error in the no-console rule preventing to invoke any method in a variable including the 'console' string.
This update fix that. Tests included.