### PR TITLE
DRAFT - fix: function-max-lines considering comments

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -9,7 +9,7 @@ title:       "Rule Index of Solhint"
 | Rule Id                                                            | Error                                                                                                                 | Recommended |
 | ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------- | ----------- |
 | [code-complexity](./rules/best-practises/code-complexity.md)       | Function has cyclomatic complexity "current" but allowed no more than maxcompl.                                       |             |
-| [function-max-lines](./rules/best-practises/function-max-lines.md) | Function body contains "count" lines but allowed no more than maxlines.                                               |             |
+| [function-max-lines](./rules/best-practises/function-max-lines.md) | Function body contains "count" lines but allowed no more than maxlines. (comments and empty lines not considered)     |             |
 | [max-line-length](./rules/best-practises/max-line-length.md)       | Line length must be no more than maxlen.                                                                              |             |
 | [max-states-count](./rules/best-practises/max-states-count.md)     | Contract has "some count" states declarations but allowed no more than maxstates.                                     | ✔️          |
 | [no-console](./rules/best-practises/no-console.md)                 | No console.log/logInt/logBytesX/logString/etc & No hardhat and forge-std console.sol import statements                | ✔️          |

--- a/docs/rules/best-practises/function-max-lines.md
+++ b/docs/rules/best-practises/function-max-lines.md
@@ -9,7 +9,7 @@ title:       "function-max-lines | Solhint"
 ![Default Severity Badge warn](https://img.shields.io/badge/Default%20Severity-warn-yellow)
 
 ## Description
-Function body contains "count" lines but allowed no more than maxlines.
+Function body contains "count" lines but allowed no more than maxlines. (comments and empty lines not considered)
 
 ## Options
 This rule accepts an array of options:

--- a/lib/rules/best-practises/function-max-lines.js
+++ b/lib/rules/best-practises/function-max-lines.js
@@ -8,7 +8,8 @@ const meta = {
   type: 'best-practises',
 
   docs: {
-    description: 'Function body contains "count" lines but allowed no more than maxlines.',
+    description:
+      'Function body contains "count" lines but allowed no more than maxlines. (comments and empty lines not considered)',
     category: 'Best Practise Rules',
     options: [
       {
@@ -47,21 +48,7 @@ class FunctionMaxLinesChecker extends BaseChecker {
   }
 
   _linesCount(node) {
-    const startStopGap = node.loc.end.line - node.loc.start.line
-
-    if (this._isSingleLineBlock(startStopGap)) {
-      return 1
-    } else {
-      return this._withoutCloseBracket(startStopGap)
-    }
-  }
-
-  _isSingleLineBlock(startStopGap) {
-    return startStopGap === 0
-  }
-
-  _withoutCloseBracket(startStopGap) {
-    return startStopGap - 1
+    return Object.keys(node.body.statements).length
   }
 
   _error(node) {

--- a/test/rules/best-practises/function-max-lines.js
+++ b/test/rules/best-practises/function-max-lines.js
@@ -4,9 +4,8 @@ const linter = require('../../../lib/index')
 const { funcWith } = require('../../common/contract-builder')
 
 describe('Linter - function-max-lines', () => {
-  it('should raise error for function with 51 lines', () => {
-    const code = funcWith(emptyLines(51))
-
+  it('should raise error for function with 51 NO EMPTY lines', () => {
+    const code = funcWith(noEmptyLines(51))
     const report = linter.processStr(code, {
       rules: { 'function-max-lines': 'error' },
     })
@@ -15,8 +14,8 @@ describe('Linter - function-max-lines', () => {
     assertErrorMessage(report, 'no more than')
   })
 
-  it('should not raise error for function with 50 lines', () => {
-    const code = funcWith(emptyLines(50))
+  it('should not raise error for function with 50 NO EMPTY lines', () => {
+    const code = funcWith(noEmptyLines(50))
 
     const report = linter.processStr(code, {
       rules: { 'function-max-lines': 'error' },
@@ -25,14 +24,63 @@ describe('Linter - function-max-lines', () => {
     assertNoErrors(report)
   })
 
-  it('should not raise error for function with 99 lines with 100 allowed', () => {
-    const code = funcWith(emptyLines(99))
+  it('should not raise error for function with 99 NO EMPTY lines when 100 lines are allowed', () => {
+    const code = funcWith(noEmptyLines(99))
 
     const report = linter.processStr(code, {
       rules: { 'function-max-lines': ['error', 100] },
     })
 
     assertNoErrors(report)
+  })
+
+  it('should not raise error for function with 11 EMPTY lines when 10 lines are allowed', () => {
+    const code = funcWith(emptyLines(11))
+
+    const report = linter.processStr(code, {
+      rules: { 'function-max-lines': ['error', 10] },
+    })
+
+    assertNoErrors(report)
+  })
+
+  it('should not raise error, skipping comments and empty lines', () => {
+    const contractCode =
+      emptyLines(11) +
+      '/*\n this is multiline comment \n this is the second line\n*/ \n' +
+      emptyLines(5) +
+      'uint256 var1;\n' +
+      'uint256 var2;\n' +
+      '// single line comment\n'
+
+    const code = funcWith(contractCode)
+
+    const report = linter.processStr(code, {
+      rules: { 'function-max-lines': ['error', 3] },
+    })
+
+    assertNoErrors(report)
+  })
+
+  it('should raise error not considering comments and empty lines but more statements than max-lines ', () => {
+    const contractCode =
+      emptyLines(11) +
+      '/*\n this is multiline comment \n this is the second line\n*/ \n' +
+      emptyLines(5) +
+      'uint256 var1;\n' +
+      'uint256 var2;\n' +
+      'uint256 var3;\n' +
+      'uint256 var4;\n' +
+      '// single line comment \n'
+
+    const code = funcWith(contractCode)
+
+    const report = linter.processStr(code, {
+      rules: { 'function-max-lines': ['error', 3] },
+    })
+
+    assertErrorCount(report, 1)
+    assertErrorMessage(report, 'no more than')
   })
 
   function repeatLines(line, count) {
@@ -43,5 +91,9 @@ describe('Linter - function-max-lines', () => {
 
   function emptyLines(count) {
     return repeatLines('', count)
+  }
+
+  function noEmptyLines(count) {
+    return repeatLines('uint256 variableN;', count)
   }
 })


### PR DESCRIPTION
This pr is to solve issue #30 
function-max-lines was considering comments and empty lines 
Now this behavior is changed. 

- empty lines
- one line comments
- and multiline comments 

Are not considered

STILL IN PROGRESS DO NOT MERGE