### PR TITLE
fix: no-unused-vars false positive for unnamed payable parameters

### DIFF
--- a/lib/rules/best-practises/no-unused-vars.js
+++ b/lib/rules/best-practises/no-unused-vars.js
@@ -31,8 +31,19 @@ class NoUnusedVarsChecker extends BaseChecker {
 
     if (!ignoreWhen(funcWithoutBlock, emptyBlock)) {
       VarUsageScope.activate(node)
+      // filters 'payable' keyword as name when defining function like this:
+      // function foo(address payable) public view {}
       node.parameters
-        .filter((parameter) => parameter.name)
+        .filter((parameter) => {
+          if (
+            parameter.typeName.name === 'address' &&
+            parameter.typeName.stateMutability === null &&
+            parameter.name === 'payable'
+          )
+            return null
+          else return parameter.name
+        })
+
         .forEach((parameter) => {
           this._addVariable(parameter)
         })

--- a/test/rules/best-practises/no-unused-vars.js
+++ b/test/rules/best-practises/no-unused-vars.js
@@ -10,6 +10,9 @@ describe('Linter - no-unused-vars', () => {
     contractWith('function a(uint a, uint b) public { uint c = a + b; }'),
     contractWith('function foo(uint a) { assembly { let t := a } }'),
     contractWith('function foo(uint a) { uint b = a; } '),
+    contractWith('function foo(address payable unUsed1, address payable) { this; } '),
+    contractWith('function foo(string memory, uint unUsed2) { this; } '),
+    contractWith('function foo(string calldata, uint unUsed3) { this; } '),
   ]
 
   UNUSED_VARS.forEach((curData) =>


### PR DESCRIPTION
This is a PR for the issue:
https://github.com/protofire/solhint/issues/250

Seems like it is fixed with this exception
Unit tests added

