### PR TITLE
support `ignoreConstructors` option for `no-empty-blocks`

### DIFF
--- a/docs/rules/best-practises/no-empty-blocks.md
+++ b/docs/rules/best-practises/no-empty-blocks.md
@@ -18,10 +18,20 @@ Code contains empty block.
 This rule accepts a string option of rule severity. Must be one of "error", "warn", "off". Default to warn.
 
 ### Example Config
+#### Simple example for warning
 ```json
 {
   "rules": {
     "no-empty-blocks": "warn"
+  }
+}
+```
+
+#### Ignoring empty constructor
+```json
+{
+  "rules": {
+    "no-empty-blocks": ["warn", {ignoreConstructors: true}]
   }
 }
 ```

--- a/docs/rules/best-practises/no-empty-blocks.md
+++ b/docs/rules/best-practises/no-empty-blocks.md
@@ -18,20 +18,10 @@ Code contains empty block.
 This rule accepts a string option of rule severity. Must be one of "error", "warn", "off". Default to warn.
 
 ### Example Config
-#### Simple example for warning
 ```json
 {
   "rules": {
     "no-empty-blocks": "warn"
-  }
-}
-```
-
-#### Ignoring empty constructor
-```json
-{
-  "rules": {
-    "no-empty-blocks": ["warn", {ignoreConstructors: true}]
   }
 }
 ```

--- a/lib/rules/best-practises/no-empty-blocks.js
+++ b/lib/rules/best-practises/no-empty-blocks.js
@@ -27,12 +27,8 @@ class NoEmptyBlocksChecker extends BaseChecker {
     this._validateContractPartsCount(node)
   }
 
-  FunctionDefinition(node) {
-    node.body.shouldIgnore = node.isConstructor && node.modifiers.length > 0
-  }
-
   Block(node) {
-    if (node.shouldIgnore) {
+    if (node.parent.isConstructor && node.parent.modifiers.length > 0) {
       return
     }
 

--- a/lib/rules/best-practises/no-empty-blocks.js
+++ b/lib/rules/best-practises/no-empty-blocks.js
@@ -1,9 +1,5 @@
 const BaseChecker = require('../base-checker')
 const { isFallbackFunction } = require('../../common/ast-types')
-const { isArray } = require('lodash')
-const DEFAULT_IGNORE_CONSTRUCTORS = false
-const DEFAULT_OPTION = { ignoreConstructors: DEFAULT_IGNORE_CONSTRUCTORS }
-const config = require('../../config')
 
 const ruleId = 'no-empty-blocks'
 const meta = {
@@ -12,37 +8,18 @@ const meta = {
   docs: {
     description: 'Code contains empty block.',
     category: 'Best Practise Rules',
-    options: [
-      {
-        description:
-          'A JSON object with a single property "ignoreConstructors" specifying if the rule should ignore constructors.',
-        default: JSON.stringify(DEFAULT_OPTION),
-      },
-    ],
   },
 
   isDefault: false,
   recommended: true,
-  defaultSetup: ['warn', DEFAULT_OPTION],
+  defaultSetup: 'warn',
 
-  schema: {
-    type: 'object',
-    properties: {
-      ignoreConstructors: {
-        type: 'boolean',
-      },
-    },
-  },
+  schema: null,
 }
 
 class NoEmptyBlocksChecker extends BaseChecker {
   constructor(reporter) {
     super(reporter, ruleId, meta)
-
-    if (reporter) {
-      const conf = config.from({ rules: reporter.config })
-      this.ignoreConstructors = conf.getObjectPropertyBoolean(ruleId, 'ignoreConstructors', false)
-    }
   }
 
   ContractDefinition(node) {
@@ -51,13 +28,14 @@ class NoEmptyBlocksChecker extends BaseChecker {
   }
 
   FunctionDefinition(node) {
-    node.body.isConstructor = node.isConstructor
+    node.body.shouldIgnore = node.isConstructor && node.modifiers.length > 0
   }
 
   Block(node) {
-    if (node.isConstructor && this.ignoreConstructors) {
+    if (node.shouldIgnore) {
       return
     }
+
     const isFallbackFunctionBlock = isFallbackFunction(node.parent)
     if (isFallbackFunctionBlock) {
       // ignore empty blocks in fallback functions

--- a/lib/rules/best-practises/no-empty-blocks.js
+++ b/lib/rules/best-practises/no-empty-blocks.js
@@ -1,5 +1,9 @@
 const BaseChecker = require('../base-checker')
 const { isFallbackFunction } = require('../../common/ast-types')
+const { isArray } = require('lodash')
+const DEFAULT_IGNORE_CONSTRUCTORS = false
+const DEFAULT_OPTION = { ignoreConstructors: DEFAULT_IGNORE_CONSTRUCTORS }
+const config = require('../../config')
 
 const ruleId = 'no-empty-blocks'
 const meta = {
@@ -8,18 +12,37 @@ const meta = {
   docs: {
     description: 'Code contains empty block.',
     category: 'Best Practise Rules',
+    options: [
+      {
+        description:
+          'A JSON object with a single property "ignoreConstructors" specifying if the rule should ignore constructors.',
+        default: JSON.stringify(DEFAULT_OPTION),
+      },
+    ],
   },
 
   isDefault: false,
   recommended: true,
-  defaultSetup: 'warn',
+  defaultSetup: ['warn', DEFAULT_OPTION],
 
-  schema: null,
+  schema: {
+    type: 'object',
+    properties: {
+      ignoreConstructors: {
+        type: 'boolean',
+      },
+    },
+  },
 }
 
 class NoEmptyBlocksChecker extends BaseChecker {
   constructor(reporter) {
     super(reporter, ruleId, meta)
+
+    if (reporter) {
+      const conf = config.from({ rules: reporter.config })
+      this.ignoreConstructors = conf.getObjectPropertyBoolean(ruleId, 'ignoreConstructors', false)
+    }
   }
 
   ContractDefinition(node) {
@@ -27,7 +50,14 @@ class NoEmptyBlocksChecker extends BaseChecker {
     this._validateContractPartsCount(node)
   }
 
+  FunctionDefinition(node) {
+    node.body.isConstructor = node.isConstructor
+  }
+
   Block(node) {
+    if (node.isConstructor && this.ignoreConstructors) {
+      return
+    }
     const isFallbackFunctionBlock = isFallbackFunction(node.parent)
     if (isFallbackFunctionBlock) {
       // ignore empty blocks in fallback functions

--- a/test/rules/best-practises/no-empty-blocks.js
+++ b/test/rules/best-practises/no-empty-blocks.js
@@ -30,6 +30,7 @@ describe('Linter - no-empty-blocks', () => {
     contractWith('enum Abc { Test1 }'),
     'contract A { uint private a; }',
     funcWith('assembly { "literal" }'),
+    contractWith('constructor () BaseContract() {  }'),
   ]
 
   BLOCKS_WITH_DEFINITIONS.forEach((curData) =>
@@ -114,11 +115,21 @@ describe('Linter - no-empty-blocks', () => {
     assertNoWarnings(report)
   })
 
-  it('should not raise error for constructor when ignoreConstructors is set to true', () => {
+  it('should raise error for empty block of [constructor]', () => {
     const code = contractWith(`constructor () {}`)
 
     const report = linter.processStr(code, {
-      rules: { 'no-empty-blocks': ['warn', { ignoreConstructors: true }] },
+      rules: { 'no-empty-blocks': 'warn' },
+    })
+
+    assertWarnsCount(report, 1)
+  })
+
+  it('should not raise error for empty block of inherited [constructor] having modifiers', () => {
+    const code = contractWith(`constructor (address addr) BaseContract(addr) {}`)
+
+    const report = linter.processStr(code, {
+      rules: { 'no-empty-blocks': 'warn' },
     })
 
     assertNoWarnings(report)

--- a/test/rules/best-practises/no-empty-blocks.js
+++ b/test/rules/best-practises/no-empty-blocks.js
@@ -115,26 +115,6 @@ describe('Linter - no-empty-blocks', () => {
     assertNoWarnings(report)
   })
 
-  it('should raise error for empty block of [constructor]', () => {
-    const code = contractWith(`constructor () {}`)
-
-    const report = linter.processStr(code, {
-      rules: { 'no-empty-blocks': 'warn' },
-    })
-
-    assertWarnsCount(report, 1)
-  })
-
-  it('should not raise error for empty block of inherited [constructor] having modifiers', () => {
-    const code = contractWith(`constructor (address addr) BaseContract(addr) {}`)
-
-    const report = linter.processStr(code, {
-      rules: { 'no-empty-blocks': 'warn' },
-    })
-
-    assertNoWarnings(report)
-  })
-
   function label(data) {
     const items = data.split('\n')
     const lastItemIndex = items.length - 1

--- a/test/rules/best-practises/no-empty-blocks.js
+++ b/test/rules/best-practises/no-empty-blocks.js
@@ -7,6 +7,7 @@ describe('Linter - no-empty-blocks', () => {
     funcWith('if (a < b) {  }'),
     contractWith('struct Abc {  }'),
     contractWith('enum Abc {  }'),
+    contractWith('constructor () {  }'),
     'contract A { }',
     funcWith('assembly {  }'),
   ]
@@ -108,6 +109,16 @@ describe('Linter - no-empty-blocks', () => {
 
     const report = linter.processStr(code, {
       rules: { 'no-empty-blocks': 'warn' },
+    })
+
+    assertNoWarnings(report)
+  })
+
+  it('should not raise error for constructor when ignoreConstructors is set to true', () => {
+    const code = contractWith(`constructor () {}`)
+
+    const report = linter.processStr(code, {
+      rules: { 'no-empty-blocks': ['warn', { ignoreConstructors: true }] },
     })
 
     assertNoWarnings(report)


### PR DESCRIPTION
# A new example
You can set `ignoreConstructors` simlar with `func-visibility` rule.

```json
{
  "rules": {
    "no-empty-blocks": ["warn", {ignoreConstructors: true}]
  }
}
```

# Related Issue
#242 