### PR TITLE
fix: --max-warnings unusable

### DIFF
--- a/solhint.js
+++ b/solhint.js
@@ -94,7 +94,7 @@ function execMainAction() {
 
   if (printReports(reports, formatterFn)) {
     if (
-      program.maxWarnings &&
+      program.opts().maxWarnings &&
       reports &&
       reports.length > 0 &&
       !reports[0].errorCount &&


### PR DESCRIPTION
The --max-warnings flag is never considered due to a mis-referenced parameter