### PR TITLE
Allow `$` in casing-related rules

### DIFF
--- a/lib/common/identifier-naming.js
+++ b/lib/common/identifier-naming.js
@@ -12,7 +12,7 @@ module.exports = {
   },
 
   isCamelCase(text) {
-    return match(text, /[A-Z]+[a-zA-Z0-9$]*/)
+    return match(text, /[A-Z$]+[a-zA-Z0-9$]*/)
   },
 
   isNotCamelCase(text) {
@@ -20,7 +20,7 @@ module.exports = {
   },
 
   isUpperSnakeCase(text) {
-    return match(text, /_{0,2}[A-Z0-9]+[_A-Z0-9]*/)
+    return match(text, /_{0,2}[A-Z0-9$]+[_A-Z0-9$]*/)
   },
 
   isNotUpperSnakeCase(text) {

--- a/lib/common/identifier-naming.js
+++ b/lib/common/identifier-naming.js
@@ -4,7 +4,7 @@ function match(text, regex) {
 
 module.exports = {
   isMixedCase(text) {
-    return match(text, /[_]*[a-z]+[a-zA-Z0-9$]*[_]?/)
+    return match(text, /[_]*[a-z$]+[a-zA-Z0-9$]*[_]?/)
   },
 
   isNotMixedCase(text) {

--- a/lib/rules/naming/contract-name-camelcase.js
+++ b/lib/rules/naming/contract-name-camelcase.js
@@ -6,7 +6,7 @@ const meta = {
   type: 'naming',
 
   docs: {
-    description: 'Contract name must be in CamelCase.',
+    description: 'Contract, struct and enum names must be in CamelCase.',
     category: 'Style Guide Rules',
   },
 

--- a/lib/rules/naming/func-param-name-mixedcase.js
+++ b/lib/rules/naming/func-param-name-mixedcase.js
@@ -6,7 +6,7 @@ const meta = {
   type: 'naming',
 
   docs: {
-    description: 'Function param name must be in mixedCase',
+    description: 'Function and event param names must be in mixedCase',
     category: 'Style Guide Rules',
   },
 

--- a/test/rules/naming/const-name-snakecase.js
+++ b/test/rules/naming/const-name-snakecase.js
@@ -54,4 +54,23 @@ describe('Linter - const-name-snakecase', () => {
     assert.equal(report.errorCount, 1)
     assert.ok(report.messages[0].message.includes('SNAKE_CASE'))
   })
+
+  describe('with $ character', () => {
+    const WITH_$ = {
+      $: contractWith('uint32 private constant $ = 10;'),
+      'starting with $': contractWith('uint32 private constant $THE_CONSTANT = 10;'),
+      'containing a $': contractWith('uint32 private constant THE_$_CONSTANT = 10;'),
+      'ending with $': contractWith('uint32 private constant THE_CONSTANT$ = 10;'),
+    }
+
+    for (const [key, code] of Object.entries(WITH_$)) {
+      it(`should not raise event name error for events ${key}`, () => {
+        const report = linter.processStr(code, {
+          rules: { 'const-name-snakecase': 'error' },
+        })
+
+        assert.equal(report.errorCount, 0)
+      })
+    }
+  })
 })

--- a/test/rules/naming/contract-name-camelcase.js
+++ b/test/rules/naming/contract-name-camelcase.js
@@ -3,36 +3,129 @@ const linter = require('../../../lib/index')
 const contractWith = require('../../common/contract-builder').contractWith
 
 describe('Linter - contract-name-camelcase', () => {
-  it('should raise struct name error', () => {
-    const code = contractWith('struct a {}')
+  describe('in structs', () => {
+    it('should raise contract name error', () => {
+      const code = contractWith('struct a {}')
 
-    const report = linter.processStr(code, {
-      rules: { 'contract-name-camelcase': 'error' },
+      const report = linter.processStr(code, {
+        rules: { 'contract-name-camelcase': 'error' },
+      })
+
+      assert.equal(report.errorCount, 1)
+      assert.ok(report.messages[0].message.includes('CamelCase'))
     })
 
-    assert.equal(report.errorCount, 1)
-    assert.ok(report.messages[0].message.includes('CamelCase'))
+    it('should not raise contract name error', () => {
+      const code = contractWith('struct MyStruct {}')
+
+      const report = linter.processStr(code, {
+        rules: { 'contract-name-camelcase': 'error' },
+      })
+
+      assert.equal(report.errorCount, 0)
+    })
+
+    describe('with $ character', () => {
+      const WITH_$ = {
+        $: contractWith('struct $ {}'),
+        'starting with $': contractWith('struct $MyStruct {}'),
+        'containing a $': contractWith('struct My$Struct {}'),
+        'ending with $': contractWith('struct MyStruct$ {}'),
+      }
+
+      for (const [key, code] of Object.entries(WITH_$)) {
+        it(`should not raise contract name error for structs ${key}`, () => {
+          const report = linter.processStr(code, {
+            rules: { 'contract-name-camelcase': 'error' },
+          })
+
+          assert.equal(report.errorCount, 0)
+        })
+      }
+    })
   })
 
-  it('should raise contract name error', () => {
-    const code = 'contract a {}'
+  describe('in contracts', () => {
+    it('should raise contract name error', () => {
+      const code = 'contract a {}'
 
-    const report = linter.processStr(code, {
-      rules: { 'contract-name-camelcase': 'error' },
+      const report = linter.processStr(code, {
+        rules: { 'contract-name-camelcase': 'error' },
+      })
+
+      assert.equal(report.errorCount, 1)
+      assert.ok(report.messages[0].message.includes('CamelCase'))
     })
 
-    assert.equal(report.errorCount, 1)
-    assert.ok(report.messages[0].message.includes('CamelCase'))
+    it('should not raise contract name error', () => {
+      const code = 'contract MyContract {}'
+
+      const report = linter.processStr(code, {
+        rules: { 'contract-name-camelcase': 'error' },
+      })
+
+      assert.equal(report.errorCount, 0)
+    })
+
+    describe('with $ character', () => {
+      const WITH_$ = {
+        $: 'contract $ {}',
+        'starting with $': 'contract $MyContract {}',
+        'containing a $': 'contract My$Contract {}',
+        'ending with $': 'contract MyContract$ {}',
+      }
+
+      for (const [key, code] of Object.entries(WITH_$)) {
+        it(`should not raise contract name error for contracts ${key}`, () => {
+          const report = linter.processStr(code, {
+            rules: { 'contract-name-camelcase': 'error' },
+          })
+
+          assert.equal(report.errorCount, 0)
+        })
+      }
+    })
   })
 
-  it('should raise enum name error', () => {
-    const code = contractWith('enum abc {}')
+  describe('in enums', () => {
+    it('should raise contract name error', () => {
+      const code = contractWith('enum abc {}')
 
-    const report = linter.processStr(code, {
-      rules: { 'contract-name-camelcase': 'error' },
+      const report = linter.processStr(code, {
+        rules: { 'contract-name-camelcase': 'error' },
+      })
+
+      assert.equal(report.errorCount, 1)
+      assert.ok(report.messages[0].message.includes('CamelCase'))
     })
 
-    assert.equal(report.errorCount, 1)
-    assert.ok(report.messages[0].message.includes('CamelCase'))
+    it('should not raise contract name error', () => {
+      const code = contractWith('enum MyEnum {}')
+
+      const report = linter.processStr(code, {
+        rules: { 'contract-name-camelcase': 'error' },
+      })
+
+      assert.equal(report.errorCount, 0)
+    })
+
+    describe('with $ character', () => {
+      const WITH_$ = {
+        $: contractWith('enum $ {}'),
+        'starting with $': contractWith('enum $MyEnum {}'),
+        'containing a $': contractWith('enum My$Enum {}'),
+        'ending with $': contractWith('enum MyEnum$ {}'),
+      }
+
+      for (const [key, code] of Object.entries(WITH_$)) {
+        it(`should not raise contract name error for structs ${key}`, () => {
+          const report = linter.processStr(code, {
+            rules: { 'contract-name-camelcase': 'error' },
+          })
+
+          assert.equal(report.errorCount, 0)
+        })
+      }
+    })
   })
 })

--- a/test/rules/naming/event-name-camelcase.js
+++ b/test/rules/naming/event-name-camelcase.js
@@ -13,4 +13,33 @@ describe('Linter - event-name-camelcase', () => {
     assert.equal(report.errorCount, 1)
     assert.ok(report.messages[0].message.includes('CamelCase'))
   })
+
+  it('should not raise event name error for event in camelCase', () => {
+    const code = contractWith('event Event1(uint a);')
+
+    const report = linter.processStr(code, {
+      rules: { 'event-name-camelcase': 'error' },
+    })
+
+    assert.equal(report.errorCount, 0)
+  })
+
+  describe('with $ character', () => {
+    const WITH_$ = {
+      $: contractWith('event $(uint a);'),
+      'starting with $': contractWith('event $Event1(uint a);'),
+      'containing a $': contractWith('event Eve$nt1(uint a);'),
+      'ending with $': contractWith('event Event1$(uint a);'),
+    }
+
+    for (const [key, code] of Object.entries(WITH_$)) {
+      it(`should not raise event name error for events ${key}`, () => {
+        const report = linter.processStr(code, {
+          rules: { 'contract-name-camelcase': 'error' },
+        })
+
+        assert.equal(report.errorCount, 0)
+      })
+    }
+  })
 })

--- a/test/rules/naming/func-name-mixedcase.js
+++ b/test/rules/naming/func-name-mixedcase.js
@@ -14,7 +14,7 @@ describe('Linter - func-name-mixedcase', () => {
     assert.ok(report.messages[0].message.includes('mixedCase'))
   })
 
-  it('should dot raise incorrect func name error', () => {
+  it('should not raise incorrect func name error', () => {
     const code = contractWith('function aFunc1Nam23e () public {}')
 
     const report = linter.processStr(code, {
@@ -22,5 +22,24 @@ describe('Linter - func-name-mixedcase', () => {
     })
 
     assert.equal(report.errorCount, 0)
+  })
+
+  describe('with $ character', () => {
+    const WITH_$ = {
+      $: contractWith('function $ () public {}'),
+      'starting with $': contractWith('function $aFunc1Nam23e () public {}'),
+      'containing a $': contractWith('function aFunc$1Nam23e () public {}'),
+      'ending with $': contractWith('function aFunc1Nam23e$ () public {}'),
+    }
+
+    for (const [key, code] of Object.entries(WITH_$)) {
+      it(`should not raise func name error for functions ${key}`, () => {
+        const report = linter.processStr(code, {
+          rules: { 'func-name-mixedcase': 'error' },
+        })
+
+        assert.equal(report.errorCount, 0)
+      })
+    }
   })
 })

--- a/test/rules/naming/func-param-name-mixedcase.js
+++ b/test/rules/naming/func-param-name-mixedcase.js
@@ -3,25 +3,87 @@ const linter = require('../../../lib/index')
 const contractWith = require('../../common/contract-builder').contractWith
 
 describe('Linter - func-param-name-mixedcase', () => {
-  it('should raise incorrect func param name error', () => {
-    const code = contractWith('function funcName (uint A) public {}')
+  describe('in functions', () => {
+    it('should raise incorrect func param name error', () => {
+      const code = contractWith('function funcName (uint A) public {}')
 
-    const report = linter.processStr(code, {
-      rules: { 'func-param-name-mixedcase': 'error' },
+      const report = linter.processStr(code, {
+        rules: { 'func-param-name-mixedcase': 'error' },
+      })
+
+      assert.equal(report.errorCount, 1)
+      assert.ok(report.messages[0].message.includes('param'))
     })
 
-    assert.equal(report.errorCount, 1)
-    assert.ok(report.messages[0].message.includes('param'))
+    it('should not raise incorrect func param name error', () => {
+      const code = contractWith('function funcName (uint someParam) public {}')
+
+      const report = linter.processStr(code, {
+        rules: { 'func-param-name-mixedcase': 'error' },
+      })
+
+      assert.equal(report.errorCount, 0)
+    })
+
+    describe('with $ character', () => {
+      const WITH_$ = {
+        $: contractWith('function funcName (uint $) public {}'),
+        'starting with $': contractWith('function funcName (uint $param) public {}'),
+        'containing a $': contractWith('function funcName (uint pa$ram) public {}'),
+        'ending with $': contractWith('function funcName (uint param$) public {}'),
+      }
+
+      for (const [key, code] of Object.entries(WITH_$)) {
+        it(`should not raise func param name error for parameters ${key}`, () => {
+          const report = linter.processStr(code, {
+            rules: { 'func-param-name-mixedcase': 'error' },
+          })
+
+          assert.equal(report.errorCount, 0)
+        })
+      }
+    })
   })
 
-  it('should raise var name error for event arguments illegal styling', () => {
-    const code = contractWith('event Event1(uint B);')
+  describe('in events', () => {
+    it('should raise var name error for event arguments illegal styling', () => {
+      const code = contractWith('event Event1(uint B);')
 
-    const report = linter.processStr(code, {
-      rules: { 'func-param-name-mixedcase': 'error' },
+      const report = linter.processStr(code, {
+        rules: { 'func-param-name-mixedcase': 'error' },
+      })
+
+      assert.equal(report.errorCount, 1)
+      assert.ok(report.messages[0].message.includes('mixedCase'))
     })
 
-    assert.equal(report.errorCount, 1)
-    assert.ok(report.messages[0].message.includes('mixedCase'))
+    it('should not raise incorrect func param name error', () => {
+      const code = contractWith('event Event1(uint someParam);')
+
+      const report = linter.processStr(code, {
+        rules: { 'func-param-name-mixedcase': 'error' },
+      })
+
+      assert.equal(report.errorCount, 0)
+    })
+
+    describe('with $ character', () => {
+      const WITH_$ = {
+        $: contractWith('event Event1(uint $);'),
+        'starting with $': contractWith('event Event1(uint $param);'),
+        'containing a $': contractWith('event Event1(uint pa$ram);'),
+        'ending with $': contractWith('event Event1(uint param$);'),
+      }
+
+      for (const [key, code] of Object.entries(WITH_$)) {
+        it(`should not raise func name error for functions ${key}`, () => {
+          const report = linter.processStr(code, {
+            rules: { 'func-name-mixedcase': 'error' },
+          })
+
+          assert.equal(report.errorCount, 0)
+        })
+      }
+    })
   })
 })

--- a/test/rules/naming/modifier-name-mixedcase.js
+++ b/test/rules/naming/modifier-name-mixedcase.js
@@ -23,4 +23,23 @@ describe('Linter - modifier-name-mixedcase', () => {
 
     assert.equal(report.errorCount, 0)
   })
+
+  describe('with $ character', () => {
+    const WITH_$ = {
+      $: contractWith('modifier $(address a) { }'),
+      'starting with $': contractWith('modifier $ownedBy(address a) { }'),
+      'containing a $': contractWith('modifier owned$By(address a) { }'),
+      'ending with $': contractWith('modifier ownedBy$(address a) { }'),
+    }
+
+    for (const [key, code] of Object.entries(WITH_$)) {
+      it(`should not raise func name error for functions ${key}`, () => {
+        const report = linter.processStr(code, {
+          rules: { 'modifier-name-mixedcase': 'error' },
+        })
+
+        assert.equal(report.errorCount, 0)
+      })
+    }
+  })
 })

--- a/test/rules/naming/var-name-mixedcase.js
+++ b/test/rules/naming/var-name-mixedcase.js
@@ -46,4 +46,21 @@ describe('Linter - var-name-mixedcase', () => {
 
     assert.equal(report.errorCount, 0)
   })
+
+  const WITH_$ = {
+    $: contractWith('uint32 private $ = 10;'),
+    'starting with $': contractWith('uint32 private $D = 10;'),
+    'containing a $': contractWith('uint32 private testWith$Contained = 10;'),
+    'ending with $': contractWith('uint32 private testWithEnding$ = 10;'),
+  }
+
+  for (const [key, code] of Object.entries(WITH_$)) {
+    it(`should not raise var name error for variables ${key}`, () => {
+      const report = linter.processStr(code, {
+        rules: { 'no-unused-vars': 'error', 'var-name-mixedcase': 'error' },
+      })
+
+      assert.equal(report.errorCount, 0)
+    })
+  }
 })

--- a/test/rules/naming/var-name-mixedcase.js
+++ b/test/rules/naming/var-name-mixedcase.js
@@ -47,20 +47,22 @@ describe('Linter - var-name-mixedcase', () => {
     assert.equal(report.errorCount, 0)
   })
 
-  const WITH_$ = {
-    $: contractWith('uint32 private $ = 10;'),
-    'starting with $': contractWith('uint32 private $D = 10;'),
-    'containing a $': contractWith('uint32 private testWith$Contained = 10;'),
-    'ending with $': contractWith('uint32 private testWithEnding$ = 10;'),
-  }
+  describe('with $ character', () => {
+    const WITH_$ = {
+      $: contractWith('uint32 private $ = 10;'),
+      'starting with $': contractWith('uint32 private $D = 10;'),
+      'containing a $': contractWith('uint32 private testWith$Contained = 10;'),
+      'ending with $': contractWith('uint32 private testWithEnding$ = 10;'),
+    }
 
-  for (const [key, code] of Object.entries(WITH_$)) {
-    it(`should not raise var name error for variables ${key}`, () => {
-      const report = linter.processStr(code, {
-        rules: { 'no-unused-vars': 'error', 'var-name-mixedcase': 'error' },
+    for (const [key, code] of Object.entries(WITH_$)) {
+      it(`should not raise var name error for variables ${key}`, () => {
+        const report = linter.processStr(code, {
+          rules: { 'no-unused-vars': 'error', 'var-name-mixedcase': 'error' },
+        })
+
+        assert.equal(report.errorCount, 0)
       })
-
-      assert.equal(report.errorCount, 0)
-    })
-  }
+    }
+  })
 })


### PR DESCRIPTION
Fixes #452

I acknowledge the issue requires a bit more discussion but I'm opening this PR in case there's no push back for this rule change.

Alternatively, we can pass it as part of the rule configuration, similar to:

```js
{
  "rules": {
    "var-name-mixedcase": ["error", { ignore$: true }]
  }
}
```