### PR TITLE
Fix explicit-types default value

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -15,11 +15,6 @@ module.exports = {
     return _.isBoolean(configVal) ? configVal : defaultValue
   },
 
-  getStringByPath(path, defaultValue) {
-    const configVal = _.get(this, path)
-    return _.isString(configVal) ? configVal : defaultValue
-  },
-
   getNumber(ruleName, defaultValue) {
     return this.getNumberByPath(`rules["${ruleName}"][1]`, defaultValue)
   },
@@ -33,6 +28,11 @@ module.exports = {
   },
 
   getString(ruleName, defaultValue) {
-    return this.getStringByPath(`rules["${ruleName}"][1]`, defaultValue)
+    if (this.rules && this.rules[ruleName]) {
+      const ruleValue = this.rules[ruleName]
+      return Array.isArray(ruleValue) ? ruleValue[1] : defaultValue
+    } else {
+      return defaultValue
+    }
   },
 }

--- a/lib/rules/best-practises/explicit-types.js
+++ b/lib/rules/best-practises/explicit-types.js
@@ -64,11 +64,14 @@ class ExplicitTypesChecker extends BaseChecker {
     super(reporter, ruleId, meta)
     this.configOption = (config && config.getString(ruleId, DEFAULT_OPTION)) || DEFAULT_OPTION
     this.isExplicit = this.configOption === 'explicit'
-
-    this.validateConfigOption(this.configOption)
   }
 
   VariableDeclaration(node) {
+    if (!VALID_CONFIGURATION_OPTIONS.includes(this.configOption)) {
+      this.error(node, 'Error: Config error on [explicit-types]. See explicit-types.md.')
+      return
+    }
+
     const typeToFind = 'ElementaryTypeName'
     const onlyTypes = this.findNamesOfElementaryTypeName(node, typeToFind)
 
@@ -87,12 +90,6 @@ class ExplicitTypesChecker extends BaseChecker {
     } else {
       this.validateVariables(EXPLICIT_TYPES, node, varsToBeChecked)
     }
-  }
-
-  validateConfigOption(configOption) {
-    const configOk = VALID_CONFIGURATION_OPTIONS.includes(configOption)
-    if (!configOk)
-      throw new Error('Error: Config error on [explicit-types]. See explicit-types.md.')
   }
 
   validateVariables(configType, node, varsToBeChecked) {

--- a/test/rules/best-practises/explicit-types.js
+++ b/test/rules/best-practises/explicit-types.js
@@ -1,4 +1,3 @@
-const assert = require('assert')
 const linter = require('../../../lib/index')
 const contractWith = require('../../common/contract-builder').contractWith
 const { assertErrorCount, assertNoErrors, assertErrorMessage } = require('../../common/asserts')
@@ -21,30 +20,24 @@ const getZeroErrosObject = () => {
 }
 
 describe('Linter - explicit-types rule', () => {
-  it('should throw an error with a wrong configuration rule example 1', () => {
+  it('should throw an error with a wrong configuration rule', () => {
     const code = contractWith('uint256 public constant SNAKE_CASE = 1;')
-    try {
-      linter.processStr(code, {
-        rules: { 'explicit-types': ['error', 'implicito'] },
-      })
-    } catch (error) {
-      assert.ok(
-        error.toString().includes('Error: Config error on [explicit-types]. See explicit-types.md.')
-      )
-    }
+
+    const report = linter.processStr(code, {
+      rules: { 'explicit-types': ['error', 'implicito'] },
+    })
+
+    assertErrorCount(report, 1)
+    assertErrorMessage(report, `Error: Config error on [explicit-types]. See explicit-types.md.`)
   })
 
-  it('should throw an error with a wrong configuration rule example 2', () => {
+  it('should NOT throw error without the config array and default should take place', () => {
     const code = contractWith('uint256 public constant SNAKE_CASE = 1;')
-    try {
-      linter.processStr(code, {
-        rules: { 'explicit-types': 'error' },
-      })
-    } catch (error) {
-      assert.ok(
-        error.toString().includes('Error: Config error on [explicit-types]. See explicit-types.md.')
-      )
-    }
+    const report = linter.processStr(code, {
+      rules: { 'explicit-types': 'error' },
+    })
+
+    assertNoErrors(report)
   })
 
   for (const key in VAR_DECLARATIONS) {


### PR DESCRIPTION
When configured like this

`rules: { 'explicit-types': 'error' },`
default value was not taking over

moreover, there was a throw method that shouldn't be there