### PR TITLE
fix: invalid JSON formatting

### DIFF
--- a/lib/formatters/json.js
+++ b/lib/formatters/json.js
@@ -58,5 +58,5 @@ module.exports = function (results) {
 
   if (finalMessage) allMessages.push(finalMessage)
 
-  return allMessages.length > 0 ? JSON.parse(JSON.stringify(allMessages)) : ''
+  return allMessages.length > 0 ? JSON.stringify(allMessages) : ''
 }


### PR DESCRIPTION
The `JSON.parse()` function converts the string to JavaScript object:
```
[
  {
    line: 10,
    column: 9,
    severity: 'Warning',
    message: 'Variable "x" is unused',
    ruleId: 'no-unused-vars',
    fix: null,
    filePath: 'src/Boolean.sol'
  },
  { conclusion: '1 problem/s (1 warning/s)' }
] 
```
instead of standard JSON:
```
[
    {
        "line": 10,
        "column": 9,
        "severity": "Warning",
        "message": 'Variable "x" is unused',
        "ruleId": "no-unused-vars",
        "fix": None,
        "filePath": "src/types/Boolean.sol"
    },
    { "conclusion": "1 problem/s (1 warning/s)" }
]
```

This prevents JSON parsing of the generated output.

