### PR TITLE
Enhance explicit types sensitivity

### DIFF
--- a/docs/rules/best-practises/explicit-types.md
+++ b/docs/rules/best-practises/explicit-types.md
@@ -48,6 +48,12 @@ uint256 public variableName
 uint public variableName
 ```
 
+#### If explicit is selected
+
+```solidity
+uint256 public variableName = uint256(5)
+```
+
 ### 👎 Examples of **incorrect** code for this rule
 
 #### If explicit is selected
@@ -60,6 +66,12 @@ uint public variableName
 
 ```solidity
 uint256 public variableName
+```
+
+#### At any setting
+
+```solidity
+uint public variableName = uint256(5)
 ```
 
 ## Version

--- a/lib/rules/best-practises/explicit-types.js
+++ b/lib/rules/best-practises/explicit-types.js
@@ -35,6 +35,10 @@ const meta = {
           description: 'If implicit is selected',
           code: 'uint public variableName',
         },
+        {
+          description: 'If explicit is selected',
+          code: 'uint256 public variableName = uint256(5)',
+        },
       ],
       bad: [
         {
@@ -44,6 +48,10 @@ const meta = {
         {
           description: 'If implicit is selected',
           code: 'uint256 public variableName',
+        },
+        {
+          description: 'If implicit is selected',
+          code: 'uint public variableName = uint256(5)',
         },
       ],
     },
@@ -68,6 +76,19 @@ class ExplicitTypesChecker extends BaseChecker {
   }
 
   VariableDeclaration(node) {
+    this.validateInNode(node)
+  }
+
+  VariableDeclarationStatement(node) {
+    if (!node.initialValue) return
+    this.validateInNode(node.initialValue)
+  }
+
+  ExpressionStatement(node) {
+    this.validateInNode(node)
+  }
+
+  validateInNode(node) {
     if (!VALID_CONFIGURATION_OPTIONS.includes(this.configOption)) {
       this.error(node, 'Error: Config error on [explicit-types]. See explicit-types.md.')
       return

--- a/lib/rules/best-practises/explicit-types.js
+++ b/lib/rules/best-practises/explicit-types.js
@@ -50,7 +50,7 @@ const meta = {
           code: 'uint256 public variableName',
         },
         {
-          description: 'If implicit is selected',
+          description: 'At any setting',
           code: 'uint public variableName = uint256(5)',
         },
       ],

--- a/test/fixtures/best-practises/explicit-types.js
+++ b/test/fixtures/best-practises/explicit-types.js
@@ -119,6 +119,12 @@ const VAR_DECLARATIONS = {
     errorsExplicit: 1,
   },
 
+  fixedArrayCastInDeclaration: {
+    code: 'uint[] public arr = [uint(1),2,3];',
+    errorsImplicit: 0,
+    errorsExplicit: 2,
+  },
+
   fixedArrayOfArrays: {
     code: 'uint256[] public arr = [[1,2,3]];',
     errorsImplicit: 1,
@@ -129,6 +135,42 @@ const VAR_DECLARATIONS = {
     code: 'uint[] public arr = [1,2,3]; mapping(uint256 => arr) mapOfFixedArray;',
     errorsImplicit: 1,
     errorsExplicit: 1,
+  },
+
+  castInStateVariableDeclaration: {
+    code: 'uint256 public varUint256 = uint256(1); uint public varUint = uint(1);',
+    errorsImplicit: 2,
+    errorsExplicit: 2,
+  },
+
+  castInsideFunctionAtDeclarationUint256: {
+    code: 'function withUint256() external { uint256 varUint256 = uint256(1); }',
+    errorsImplicit: 2,
+    errorsExplicit: 0,
+  },
+
+  castInsideFunctionAtDeclarationUint: {
+    code: 'function withUint() external { uint varUint = uint(1); }',
+    errorsImplicit: 0,
+    errorsExplicit: 2,
+  },
+
+  castInsideFunctionUint: {
+    code: 'function withUint() external { uint varUint; varUint = uint(1);}',
+    errorsImplicit: 0,
+    errorsExplicit: 2,
+  },
+
+  castInsideFunctionUint256: {
+    code: 'function withUint256() external { uint256 varUint; varUint = uint256(1);}',
+    errorsImplicit: 2,
+    errorsExplicit: 0,
+  },
+
+  castInsideModifier: {
+    code: 'modifier withUint256() { _; uint256 varUint; varUint = uint256(1);}',
+    errorsImplicit: 2,
+    errorsExplicit: 0,
   },
 }
 


### PR DESCRIPTION
Fixes #492 

Also added new tests for `explicit-types` rule. The previous implementation fails these tests.

The rule is not bound to nodes of type `ElementaryTypeName`, as they are sometimes duplicated, which leads to unnecessary triggers.