### PR TITLE
Fix generate docs links

### DIFF
--- a/scripts/generate-rule-docs.js
+++ b/scripts/generate-rule-docs.js
@@ -191,21 +191,24 @@ function linkToVersion(version) {
 }
 
 function linkToSource(rule) {
-  const link = rule.file.replace(path.resolve(path.join(__dirname, '..')), '')
+  const link = localPathToUri(rule.file)
   return `https://github.com/protofire/solhint/tree/master${link}`
 }
 
 function linkToDocumentSource(rule) {
-  const link = rule.file
-    .replace(path.resolve(path.join(__dirname, '..')), '')
+  const link = localPathToUri(rule.file)
     .replace('lib/rules', 'docs/rules')
     .replace(/\.js$/, '.md')
   return `https://github.com/protofire/solhint/tree/master${link}`
 }
 
 function linkToTestCase(rule) {
-  const link = rule.file.replace(path.resolve(path.join(__dirname, '..', 'lib', 'rules')), '')
+  const link = localPathToUri(rule.file).replace('lib/rules/', '')
   return `https://github.com/protofire/solhint/tree/master/test/rules${link}`
+}
+
+function localPathToUri(file) {
+  return file.replace(path.resolve(path.join(__dirname, '..')), '').split(path.sep).join('/')
 }
 
 function loadExamples(rule) {


### PR DESCRIPTION
The old version of the script did not correctly generate links when using Windows OS due to differences in the path format.