### PR TITLE
🐛 one-contract-per-file: ignore interfaces

### DIFF
--- a/lib/rules/best-practises/one-contract-per-file.js
+++ b/lib/rules/best-practises/one-contract-per-file.js
@@ -33,7 +33,7 @@ class OneContractPerFileChecker extends BaseChecker {
 
   SourceUnit(node) {
     const contractDefinitionCount = node.children.reduce((count, child) => {
-      if (child.type === 'ContractDefinition') {
+      if (child.type === 'ContractDefinition' && child.kind !== 'interface') {
         return count + 1
       }
       return count

--- a/test/fixtures/best-practises/one-contract-per-file.js
+++ b/test/fixtures/best-practises/one-contract-per-file.js
@@ -33,4 +33,40 @@ const THREE_CONTRACTS = `
         uint256 public constant TESTC = "testC";
     }
     `
-module.exports = { ONE_CONTRACT, TWO_CONTRACTS, THREE_CONTRACTS }
+
+const TWO_LIBRARIES = `
+    pragma solidity 0.8.0;
+    
+    library A { }
+
+    library B { }
+    `
+
+const ONE_CONTRACT_WITH_INTERFACES = `
+    pragma solidity 0.8.0;
+    
+    contract A { }
+
+    interface B { }
+
+    interface C { }
+    `
+
+const ONE_LIBRARY_WITH_INTERFACES = `
+    pragma solidity 0.8.0;
+    
+    library A { }
+
+    interface B { }
+
+    interface C { }
+    `
+
+module.exports = {
+  ONE_CONTRACT,
+  TWO_CONTRACTS,
+  THREE_CONTRACTS,
+  TWO_LIBRARIES,
+  ONE_CONTRACT_WITH_INTERFACES,
+  ONE_LIBRARY_WITH_INTERFACES,
+}

--- a/test/rules/best-practises/one-contract-per-file.js
+++ b/test/rules/best-practises/one-contract-per-file.js
@@ -13,6 +13,26 @@ describe('Linter - one-contract-per-file', () => {
     assertNoWarnings(report)
   })
 
+  it('should not raise error for ONE contract and multiple interfaces in the same file', () => {
+    const code = contracts.ONE_CONTRACT_WITH_INTERFACES
+
+    const report = linter.processStr(code, {
+      rules: { 'one-contract-per-file': 'error' },
+    })
+
+    assertNoWarnings(report)
+  })
+
+  it('should not raise error for ONE library and multiple interfaces in the same file', () => {
+    const code = contracts.ONE_LIBRARY_WITH_INTERFACES
+
+    const report = linter.processStr(code, {
+      rules: { 'one-contract-per-file': 'error' },
+    })
+
+    assertNoWarnings(report)
+  })
+
   it('should raise error for TWO contracts in same file', () => {
     const code = contracts.TWO_CONTRACTS
 
@@ -33,5 +53,16 @@ describe('Linter - one-contract-per-file', () => {
 
     assertErrorCount(report, 1)
     assertErrorMessage(report, 'Found more than One contract per file. 3 contracts found!')
+  })
+
+  it('should raise error for TWO libraries in same file', () => {
+    const code = contracts.TWO_LIBRARIES
+
+    const report = linter.processStr(code, {
+      rules: { 'one-contract-per-file': 'error' },
+    })
+
+    assertErrorCount(report, 1)
+    assertErrorMessage(report, 'Found more than One contract per file. 2 contracts found!')
   })
 })


### PR DESCRIPTION
according to the [style guide](https://docs.soliditylang.org/en/latest/style-guide.html#contract-and-library-names):
> If a contract file includes multiple **contracts and/or libraries**, then the filename should match the core contract. This is not recommended however if it can be avoided.