### PR TITLE
feat: add sarif formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Linter for Solidity programming language
 Options:
 
   -V, --version                           output the version number
-  -f, --formatter [name]                  report formatter name (stylish, table, tap, unix, json, compact)
+  -f, --formatter [name]                  report formatter name (stylish, table, tap, unix, json, compact, sarif)
   -w, --max-warnings [maxWarningsNumber]  number of allowed warnings
   -c, --config [file_name]                file to use as your .solhint.json
   -q, --quiet                             report errors only - default: false

--- a/e2e/formatters-test.js
+++ b/e2e/formatters-test.js
@@ -346,7 +346,7 @@ describe('e2e', function () {
       })
     })
 
-    describe.only('sarif formatter tests', () => {
+    describe('sarif formatter tests', () => {
       const formatterType = 'sarif'
 
       it('should always output with correct SARIF version and tool metadata', () => {

--- a/lib/formatters/README.md
+++ b/lib/formatters/README.md
@@ -8,4 +8,5 @@ files in this directory are pulled from eslint repository:
 - stylish.js: eslint - Sindre Sorhus
 - json.js: eslint - Artur Lukianov
 - compact.js: eslint - Nicholas C. Zakas
+- sarif.js: [@microsoft/eslint-formatter-sarif](https://www.npmjs.com/package/@microsoft/eslint-formatter-sarif)
   

--- a/lib/formatters/sarif.js
+++ b/lib/formatters/sarif.js
@@ -1,13 +1,10 @@
-/* eslint-disable unicorn/no-null */
 /**
  * @fileoverview SARIF v2.1 formatter
  * @author Adapted for solhint by @eshaan7 (Original: Microsoft <https://www.npmjs.com/package/@microsoft/eslint-formatter-sarif>)
  */
 
-'use strict';
-
-const url = require('url');
-const lodash = require('lodash');
+const url = require('url')
+const lodash = require('lodash')
 
 //------------------------------------------------------------------------------
 // Helper Functions
@@ -21,11 +18,10 @@ const lodash = require('lodash');
 function getSolhintVersion() {
   try {
     // Resolve solhint relative to main entry script, not the formatter
-    const solhintPackageJson = require('../../package.json');
-    return solhintPackageJson.version;
+    const solhintPackageJson = require('../../package.json')
+    return solhintPackageJson.version
   } catch {
     // Formatter was not called from solhint, return undefined
-    return;
   }
 }
 
@@ -37,9 +33,9 @@ function getSolhintVersion() {
  */
 function getResultLevel(message) {
   if (message.fatal || message.severity === 2) {
-    return 'error';
+    return 'error'
   }
-  return 'warning';
+  return 'warning'
 }
 
 //------------------------------------------------------------------------------
@@ -47,7 +43,7 @@ function getResultLevel(message) {
 //------------------------------------------------------------------------------
 
 module.exports = function (results, data) {
-  const rulesMeta = lodash.get(data, 'rulesMeta', null);
+  const rulesMeta = lodash.get(data, 'rulesMeta', null)
 
   const sarifLog = {
     version: '2.1.0',
@@ -63,20 +59,20 @@ module.exports = function (results, data) {
         },
       },
     ],
-  };
-
-  const solhintVersion = getSolhintVersion();
-  if (typeof solhintVersion !== 'undefined') {
-    sarifLog.runs[0].tool.driver.version = solhintVersion;
   }
 
-  const sarifFiles = {};
-  const sarifArtifactIndices = {};
-  let nextArtifactIndex = 0;
-  const sarifRules = {};
-  const sarifRuleIndices = {};
-  let nextRuleIndex = 0;
-  const sarifResults = [];
+  const solhintVersion = getSolhintVersion()
+  if (typeof solhintVersion !== 'undefined') {
+    sarifLog.runs[0].tool.driver.version = solhintVersion
+  }
+
+  const sarifFiles = {}
+  const sarifArtifactIndices = {}
+  let nextArtifactIndex = 0
+  const sarifRules = {}
+  const sarifRuleIndices = {}
+  let nextRuleIndex = 0
+  const sarifResults = []
 
   // Emit a tool configuration notification with this id if ESLint emits a message with
   // no ruleId (which indicates an internal error in ESLint).
@@ -85,28 +81,28 @@ module.exports = function (results, data) {
   // tool execution notifications, or a mixture of the two, based on the properties of the
   // message. https://github.com/microsoft/sarif-sdk/issues/1798, "ESLint formatter can't
   // distinguish between an internal error and a misconfiguration", tracks this issue.
-  const internalErrorId = 'ESL0999';
+  const internalErrorId = 'ESL0999'
 
-  const toolConfigurationNotifications = [];
-  let executionSuccessful = true;
+  const toolConfigurationNotifications = []
+  let executionSuccessful = true
 
   for (const result of results) {
     // Only add it if not already there.
     if (typeof sarifFiles[result.filePath] === 'undefined') {
-      sarifArtifactIndices[result.filePath] = nextArtifactIndex++;
+      sarifArtifactIndices[result.filePath] = nextArtifactIndex++
 
       // Create a new entry in the files dictionary.
       sarifFiles[result.filePath] = {
         location: {
           uri: url.pathToFileURL(result.filePath),
         },
-      };
+      }
 
       const containsSuppressedMessages =
-        result.suppressedMessages && result.suppressedMessages.length > 0;
+        result.suppressedMessages && result.suppressedMessages.length > 0
       const messages = containsSuppressedMessages
         ? [...result.messages, ...result.suppressedMessages]
-        : result.messages;
+        : result.messages
 
       if (messages.length > 0) {
         for (const message of messages) {
@@ -125,17 +121,17 @@ module.exports = function (results, data) {
                 },
               },
             ],
-          };
+          }
 
           if (message.ruleId) {
-            sarifRepresentation.ruleId = message.ruleId;
+            sarifRepresentation.ruleId = message.ruleId
 
             if (rulesMeta && typeof sarifRules[message.ruleId] === 'undefined') {
-              const meta = rulesMeta[message.ruleId];
+              const meta = rulesMeta[message.ruleId]
 
               // An unknown ruleId will return null. This check prevents unit test failure.
               if (meta) {
-                sarifRuleIndices[message.ruleId] = nextRuleIndex++;
+                sarifRuleIndices[message.ruleId] = nextRuleIndex++
 
                 if (meta.docs) {
                   // Create a new entry in the rules dictionary.
@@ -145,11 +141,11 @@ module.exports = function (results, data) {
                     properties: {
                       category: meta.docs.category,
                     },
-                  };
+                  }
                   if (meta.docs.description) {
                     sarifRules[message.ruleId].shortDescription = {
                       text: meta.docs.description,
-                    };
+                    }
                   }
                   // Some rulesMetas do not have docs property
                 } else {
@@ -159,13 +155,13 @@ module.exports = function (results, data) {
                     properties: {
                       category: 'No category provided',
                     },
-                  };
+                  }
                 }
               }
             }
 
             if (sarifRuleIndices[message.ruleId] !== 'undefined') {
-              sarifRepresentation.ruleIndex = sarifRuleIndices[message.ruleId];
+              sarifRepresentation.ruleIndex = sarifRuleIndices[message.ruleId]
             }
 
             if (containsSuppressedMessages) {
@@ -174,9 +170,9 @@ module.exports = function (results, data) {
                   return {
                     kind: suppression.kind === 'directive' ? 'inSource' : 'external',
                     justification: suppression.justification,
-                  };
+                  }
                 })
-                : [];
+                : []
             }
           } else {
             // ESLint produces a message with no ruleId when it encounters an internal
@@ -185,7 +181,7 @@ module.exports = function (results, data) {
             // than a ruleId property.
             sarifRepresentation.descriptor = {
               id: internalErrorId,
-            };
+            }
 
             // As far as we know, whenever ESLint produces a message with no rule id,
             // it has severity: 2 which corresponds to a SARIF error. But check here
@@ -193,40 +189,39 @@ module.exports = function (results, data) {
             if (sarifRepresentation.level === 'error') {
               // An error-level notification means that the tool failed to complete
               // its task.
-              executionSuccessful = false;
+              executionSuccessful = false
             }
           }
 
           if (message.line > 0 || message.column > 0) {
-            sarifRepresentation.locations[0].physicalLocation.region = {};
+            sarifRepresentation.locations[0].physicalLocation.region = {}
             if (message.line > 0) {
-              sarifRepresentation.locations[0].physicalLocation.region.startLine = message.line;
+              sarifRepresentation.locations[0].physicalLocation.region.startLine = message.line
             }
             if (message.column > 0) {
-              sarifRepresentation.locations[0].physicalLocation.region.startColumn = message.column;
+              sarifRepresentation.locations[0].physicalLocation.region.startColumn = message.column
             }
             if (message.endLine > 0) {
-              sarifRepresentation.locations[0].physicalLocation.region.endLine = message.endLine;
+              sarifRepresentation.locations[0].physicalLocation.region.endLine = message.endLine
             }
             if (message.endColumn > 0) {
-              sarifRepresentation.locations[0].physicalLocation.region.endColumn =
-                message.endColumn;
+              sarifRepresentation.locations[0].physicalLocation.region.endColumn = message.endColumn
             }
           }
 
           if (message.source) {
             // Create an empty region if we don't already have one from the line / column block above.
             sarifRepresentation.locations[0].physicalLocation.region =
-              sarifRepresentation.locations[0].physicalLocation.region || {};
+              sarifRepresentation.locations[0].physicalLocation.region || {}
             sarifRepresentation.locations[0].physicalLocation.region.snippet = {
               text: message.source,
-            };
+            }
           }
 
           if (message.ruleId) {
-            sarifResults.push(sarifRepresentation);
+            sarifResults.push(sarifRepresentation)
           } else {
-            toolConfigurationNotifications.push(sarifRepresentation);
+            toolConfigurationNotifications.push(sarifRepresentation)
           }
         }
       }
@@ -234,30 +229,30 @@ module.exports = function (results, data) {
   }
 
   if (Object.keys(sarifFiles).length > 0) {
-    sarifLog.runs[0].artifacts = [];
+    sarifLog.runs[0].artifacts = []
 
     for (const path of Object.keys(sarifFiles)) {
-      sarifLog.runs[0].artifacts.push(sarifFiles[path]);
+      sarifLog.runs[0].artifacts.push(sarifFiles[path])
     }
   }
 
   // Per the SARIF spec §3.14.23, run.results must be present even if there are no results.
   // This provides a positive indication that the run completed and no results were found.
-  sarifLog.runs[0].results = sarifResults;
+  sarifLog.runs[0].results = sarifResults
 
   if (toolConfigurationNotifications.length > 0) {
     sarifLog.runs[0].invocations = [
       {
-        toolConfigurationNotifications: toolConfigurationNotifications,
-        executionSuccessful: executionSuccessful,
+        toolConfigurationNotifications,
+        executionSuccessful,
       },
-    ];
+    ]
   }
 
   if (Object.keys(sarifRules).length > 0) {
     for (const ruleId of Object.keys(sarifRules)) {
-      const rule = sarifRules[ruleId];
-      sarifLog.runs[0].tool.driver.rules.push(rule);
+      const rule = sarifRules[ruleId]
+      sarifLog.runs[0].tool.driver.rules.push(rule)
     }
   }
 
@@ -265,5 +260,5 @@ module.exports = function (results, data) {
     sarifLog,
     null, // replacer function
     2 // # of spaces for indents
-  );
-};
+  )
+}

--- a/lib/formatters/sarif.js
+++ b/lib/formatters/sarif.js
@@ -167,11 +167,11 @@ module.exports = function (results, data) {
             if (containsSuppressedMessages) {
               sarifRepresentation.suppressions = message.suppressions
                 ? message.suppressions.map((suppression) => {
-                  return {
-                    kind: suppression.kind === 'directive' ? 'inSource' : 'external',
-                    justification: suppression.justification,
-                  }
-                })
+                    return {
+                      kind: suppression.kind === 'directive' ? 'inSource' : 'external',
+                      justification: suppression.justification,
+                    }
+                  })
                 : []
             }
           } else {

--- a/lib/formatters/sarif.js
+++ b/lib/formatters/sarif.js
@@ -1,0 +1,269 @@
+/* eslint-disable unicorn/no-null */
+/**
+ * @fileoverview SARIF v2.1 formatter
+ * @author Adapted for solhint by @eshaan7 (Original: Microsoft <https://www.npmjs.com/package/@microsoft/eslint-formatter-sarif>)
+ */
+
+'use strict';
+
+const url = require('url');
+const lodash = require('lodash');
+
+//------------------------------------------------------------------------------
+// Helper Functions
+//------------------------------------------------------------------------------
+
+/**
+ * Returns the version of used solhint package
+ * @returns {string} solhint version or undefined
+ * @private
+ */
+function getSolhintVersion() {
+  try {
+    // Resolve solhint relative to main entry script, not the formatter
+    const solhintPackageJson = require('../../package.json');
+    return solhintPackageJson.version;
+  } catch {
+    // Formatter was not called from solhint, return undefined
+    return;
+  }
+}
+
+/**
+ * Returns the severity of warning or error
+ * @param {Object} message message object to examine
+ * @returns {string} severity level
+ * @private
+ */
+function getResultLevel(message) {
+  if (message.fatal || message.severity === 2) {
+    return 'error';
+  }
+  return 'warning';
+}
+
+//------------------------------------------------------------------------------
+// Public Interface
+//------------------------------------------------------------------------------
+
+module.exports = function (results, data) {
+  const rulesMeta = lodash.get(data, 'rulesMeta', null);
+
+  const sarifLog = {
+    version: '2.1.0',
+    $schema: 'http://json.schemastore.org/sarif-2.1.0-rtm.5',
+    runs: [
+      {
+        tool: {
+          driver: {
+            name: 'solhint',
+            informationUri: 'https://github.com/protofire/solhint',
+            rules: [],
+          },
+        },
+      },
+    ],
+  };
+
+  const solhintVersion = getSolhintVersion();
+  if (typeof solhintVersion !== 'undefined') {
+    sarifLog.runs[0].tool.driver.version = solhintVersion;
+  }
+
+  const sarifFiles = {};
+  const sarifArtifactIndices = {};
+  let nextArtifactIndex = 0;
+  const sarifRules = {};
+  const sarifRuleIndices = {};
+  let nextRuleIndex = 0;
+  const sarifResults = [];
+
+  // Emit a tool configuration notification with this id if ESLint emits a message with
+  // no ruleId (which indicates an internal error in ESLint).
+  //
+  // It is not clear whether we should treat these messages tool configuration notifications,
+  // tool execution notifications, or a mixture of the two, based on the properties of the
+  // message. https://github.com/microsoft/sarif-sdk/issues/1798, "ESLint formatter can't
+  // distinguish between an internal error and a misconfiguration", tracks this issue.
+  const internalErrorId = 'ESL0999';
+
+  const toolConfigurationNotifications = [];
+  let executionSuccessful = true;
+
+  for (const result of results) {
+    // Only add it if not already there.
+    if (typeof sarifFiles[result.filePath] === 'undefined') {
+      sarifArtifactIndices[result.filePath] = nextArtifactIndex++;
+
+      // Create a new entry in the files dictionary.
+      sarifFiles[result.filePath] = {
+        location: {
+          uri: url.pathToFileURL(result.filePath),
+        },
+      };
+
+      const containsSuppressedMessages =
+        result.suppressedMessages && result.suppressedMessages.length > 0;
+      const messages = containsSuppressedMessages
+        ? [...result.messages, ...result.suppressedMessages]
+        : result.messages;
+
+      if (messages.length > 0) {
+        for (const message of messages) {
+          const sarifRepresentation = {
+            level: getResultLevel(message),
+            message: {
+              text: message.message,
+            },
+            locations: [
+              {
+                physicalLocation: {
+                  artifactLocation: {
+                    uri: url.pathToFileURL(result.filePath),
+                    index: sarifArtifactIndices[result.filePath],
+                  },
+                },
+              },
+            ],
+          };
+
+          if (message.ruleId) {
+            sarifRepresentation.ruleId = message.ruleId;
+
+            if (rulesMeta && typeof sarifRules[message.ruleId] === 'undefined') {
+              const meta = rulesMeta[message.ruleId];
+
+              // An unknown ruleId will return null. This check prevents unit test failure.
+              if (meta) {
+                sarifRuleIndices[message.ruleId] = nextRuleIndex++;
+
+                if (meta.docs) {
+                  // Create a new entry in the rules dictionary.
+                  sarifRules[message.ruleId] = {
+                    id: message.ruleId,
+                    helpUri: meta.docs.url,
+                    properties: {
+                      category: meta.docs.category,
+                    },
+                  };
+                  if (meta.docs.description) {
+                    sarifRules[message.ruleId].shortDescription = {
+                      text: meta.docs.description,
+                    };
+                  }
+                  // Some rulesMetas do not have docs property
+                } else {
+                  sarifRules[message.ruleId] = {
+                    id: message.ruleId,
+                    helpUri: 'Please see details in message',
+                    properties: {
+                      category: 'No category provided',
+                    },
+                  };
+                }
+              }
+            }
+
+            if (sarifRuleIndices[message.ruleId] !== 'undefined') {
+              sarifRepresentation.ruleIndex = sarifRuleIndices[message.ruleId];
+            }
+
+            if (containsSuppressedMessages) {
+              sarifRepresentation.suppressions = message.suppressions
+                ? message.suppressions.map((suppression) => {
+                  return {
+                    kind: suppression.kind === 'directive' ? 'inSource' : 'external',
+                    justification: suppression.justification,
+                  };
+                })
+                : [];
+            }
+          } else {
+            // ESLint produces a message with no ruleId when it encounters an internal
+            // error. SARIF represents this as a tool execution notification rather
+            // than as a result, and a notification has a descriptor.id property rather
+            // than a ruleId property.
+            sarifRepresentation.descriptor = {
+              id: internalErrorId,
+            };
+
+            // As far as we know, whenever ESLint produces a message with no rule id,
+            // it has severity: 2 which corresponds to a SARIF error. But check here
+            // anyway.
+            if (sarifRepresentation.level === 'error') {
+              // An error-level notification means that the tool failed to complete
+              // its task.
+              executionSuccessful = false;
+            }
+          }
+
+          if (message.line > 0 || message.column > 0) {
+            sarifRepresentation.locations[0].physicalLocation.region = {};
+            if (message.line > 0) {
+              sarifRepresentation.locations[0].physicalLocation.region.startLine = message.line;
+            }
+            if (message.column > 0) {
+              sarifRepresentation.locations[0].physicalLocation.region.startColumn = message.column;
+            }
+            if (message.endLine > 0) {
+              sarifRepresentation.locations[0].physicalLocation.region.endLine = message.endLine;
+            }
+            if (message.endColumn > 0) {
+              sarifRepresentation.locations[0].physicalLocation.region.endColumn =
+                message.endColumn;
+            }
+          }
+
+          if (message.source) {
+            // Create an empty region if we don't already have one from the line / column block above.
+            sarifRepresentation.locations[0].physicalLocation.region =
+              sarifRepresentation.locations[0].physicalLocation.region || {};
+            sarifRepresentation.locations[0].physicalLocation.region.snippet = {
+              text: message.source,
+            };
+          }
+
+          if (message.ruleId) {
+            sarifResults.push(sarifRepresentation);
+          } else {
+            toolConfigurationNotifications.push(sarifRepresentation);
+          }
+        }
+      }
+    }
+  }
+
+  if (Object.keys(sarifFiles).length > 0) {
+    sarifLog.runs[0].artifacts = [];
+
+    for (const path of Object.keys(sarifFiles)) {
+      sarifLog.runs[0].artifacts.push(sarifFiles[path]);
+    }
+  }
+
+  // Per the SARIF spec §3.14.23, run.results must be present even if there are no results.
+  // This provides a positive indication that the run completed and no results were found.
+  sarifLog.runs[0].results = sarifResults;
+
+  if (toolConfigurationNotifications.length > 0) {
+    sarifLog.runs[0].invocations = [
+      {
+        toolConfigurationNotifications: toolConfigurationNotifications,
+        executionSuccessful: executionSuccessful,
+      },
+    ];
+  }
+
+  if (Object.keys(sarifRules).length > 0) {
+    for (const ruleId of Object.keys(sarifRules)) {
+      const rule = sarifRules[ruleId];
+      sarifLog.runs[0].tool.driver.rules.push(rule);
+    }
+  }
+
+  return JSON.stringify(
+    sarifLog,
+    null, // replacer function
+    2 // # of spaces for indents
+  );
+};

--- a/solhint.js
+++ b/solhint.js
@@ -279,8 +279,9 @@ function printReports(reports, formatter) {
     warnings.warningsNumberExceeded
   ) {
     if (!reports[0].errorCount) {
-      finalMessage = `Solhint found more warnings than the maximum specified (maximum: ${program.opts().maxWarnings
-        }, found: ${warnings.warningsCount})`
+      finalMessage = `Solhint found more warnings than the maximum specified (maximum: ${
+        program.opts().maxWarnings
+      }, found: ${warnings.warningsCount})`
       exitWithOne = true
     } else {
       finalMessage =
@@ -327,8 +328,9 @@ function getFormatter(formatter) {
   try {
     return require(`./lib/formatters/${formatterName}`)
   } catch (ex) {
-    ex.message = `\nThere was a problem loading formatter option: ${program.opts().formatter
-      } \nError: ${ex.message}`
+    ex.message = `\nThere was a problem loading formatter option: ${
+      program.opts().formatter
+    } \nError: ${ex.message}`
     throw ex
   }
 }

--- a/solhint.js
+++ b/solhint.js
@@ -21,7 +21,7 @@ function init() {
     .usage('[options] <file> [...other_files]')
     .option(
       '-f, --formatter [name]',
-      'report formatter name (stylish, table, tap, unix, json, compact)'
+      'report formatter name (stylish, table, tap, unix, json, compact, sarif)'
     )
     .option('-w, --max-warnings [maxWarningsNumber]', 'number of allowed warnings')
     .option('-c, --config [file_name]', 'file to use as your .solhint.json')
@@ -279,9 +279,8 @@ function printReports(reports, formatter) {
     warnings.warningsNumberExceeded
   ) {
     if (!reports[0].errorCount) {
-      finalMessage = `Solhint found more warnings than the maximum specified (maximum: ${
-        program.opts().maxWarnings
-      }, found: ${warnings.warningsCount})`
+      finalMessage = `Solhint found more warnings than the maximum specified (maximum: ${program.opts().maxWarnings
+        }, found: ${warnings.warningsCount})`
       exitWithOne = true
     } else {
       finalMessage =
@@ -328,9 +327,8 @@ function getFormatter(formatter) {
   try {
     return require(`./lib/formatters/${formatterName}`)
   } catch (ex) {
-    ex.message = `\nThere was a problem loading formatter option: ${
-      program.opts().formatter
-    } \nError: ${ex.message}`
+    ex.message = `\nThere was a problem loading formatter option: ${program.opts().formatter
+      } \nError: ${ex.message}`
     throw ex
   }
 }


### PR DESCRIPTION
Adds a `sarif` formatter to output [SARIF](https://sarifweb.azurewebsites.net/) report. Implementation based on [@microsoft/eslint-formatter-sarif](https://www.npmjs.com/package/@microsoft/eslint-formatter-sarif).