### PR TITLE
Exclude abi.encodeX calls from func-named-parameters

### DIFF
--- a/lib/rules/naming/func-named-parameters.js
+++ b/lib/rules/naming/func-named-parameters.js
@@ -76,7 +76,7 @@ class FunctionNamedParametersChecker extends BaseChecker {
         if (qtyNamed === 0 && qtyArgs > this.maxUnnamedArguments) {
           this.error(
             node,
-            `Named parameters missing. MIN unnamed argumenst is ${this.maxUnnamedArguments}`
+            `Named parameters missing. MIN unnamed arguments is ${this.maxUnnamedArguments}`
           )
         }
       }

--- a/lib/rules/naming/func-named-parameters.js
+++ b/lib/rules/naming/func-named-parameters.js
@@ -36,6 +36,10 @@ const meta = {
           description: 'Function call with four NAMED parameters',
           code: 'functionName({ sender: _senderAddress, amount: 1e18, token: _tokenAddress, receiver: _receiverAddress })',
         },
+        {
+          description: 'abi.encodeX call with four UNNAMED parameters',
+          code: 'abi.encodePacked(_senderAddress, 1e18, _tokenAddress, _receiverAddress )',
+        },
       ],
       bad: [
         {
@@ -67,12 +71,24 @@ class FunctionNamedParametersChecker extends BaseChecker {
     const qtyNamed = node.names.length
     const qtyArgs = node.arguments.length
 
-    if (qtyArgs !== 0) {
-      if (qtyNamed === 0 && qtyArgs > this.maxUnnamedArguments) {
-        this.error(
-          node,
-          `Named parameters missing. MIN unnamed argumenst is ${this.maxUnnamedArguments}`
-        )
+    if (!this.isAbiCall(node)) {
+      if (qtyArgs !== 0) {
+        if (qtyNamed === 0 && qtyArgs > this.maxUnnamedArguments) {
+          this.error(
+            node,
+            `Named parameters missing. MIN unnamed argumenst is ${this.maxUnnamedArguments}`
+          )
+        }
+      }
+    }
+  }
+
+  isAbiCall(node) {
+    if (node.expression.type == 'MemberAccess') {
+      if (node.expression.expression.type == 'Identifier') {
+        if (node.expression.expression.name == 'abi') {
+          return true
+        }
       }
     }
   }

--- a/lib/rules/naming/func-named-parameters.js
+++ b/lib/rules/naming/func-named-parameters.js
@@ -84,9 +84,9 @@ class FunctionNamedParametersChecker extends BaseChecker {
   }
 
   isAbiCall(node) {
-    if (node.expression.type == 'MemberAccess') {
-      if (node.expression.expression.type == 'Identifier') {
-        if (node.expression.expression.name == 'abi') {
+    if (node.expression.type === 'MemberAccess') {
+      if (node.expression.expression.type === 'Identifier') {
+        if (node.expression.expression.name === 'abi') {
           return true
         }
       }

--- a/test/rules/naming/func-named-parameters.js
+++ b/test/rules/naming/func-named-parameters.js
@@ -27,7 +27,7 @@ describe('Linter - func-named-parameters', () => {
       assertErrorCount(report, 1)
       assertErrorMessage(
         report,
-        `Named parameters missing. MIN unnamed argumenst is ${
+        `Named parameters missing. MIN unnamed arguments is ${
           minUnnamed < DEFAULT_MIN_UNNAMED_ARGUMENTS ? DEFAULT_MIN_UNNAMED_ARGUMENTS : minUnnamed
         }`
       )
@@ -90,7 +90,7 @@ describe('Linter - func-named-parameters', () => {
 
     assertErrorMessage(
       report,
-      `Named parameters missing. MIN unnamed argumenst is ${DEFAULT_MIN_UNNAMED_ARGUMENTS}`
+      `Named parameters missing. MIN unnamed arguments is ${DEFAULT_MIN_UNNAMED_ARGUMENTS}`
     )
   })
 
@@ -106,7 +106,7 @@ describe('Linter - func-named-parameters', () => {
 
     assertErrorMessage(
       report,
-      `Named parameters missing. MIN unnamed argumenst is ${DEFAULT_MIN_UNNAMED_ARGUMENTS}`
+      `Named parameters missing. MIN unnamed arguments is ${DEFAULT_MIN_UNNAMED_ARGUMENTS}`
     )
   })
 })


### PR DESCRIPTION
Solhint regularly complains about the `named-parameters` rule when all I'm doing is throwing a bunch of data into `abi.encode()` or `abi.encodePacked()`.

Rather than annotating every single `abi.encodeX()` call with a `//solhint-disable` - I think it makes more sense to exclude `abi.encodeX()` calls from this rule at the rule implementation.

Tested locally on the contract I'm currently writing and works as expected.