### PR TITLE
Add pre-commit hook definition with test

### DIFF
--- a/.github/workflows/PRE-COMMIT-HOOK-TEST.yml
+++ b/.github/workflows/PRE-COMMIT-HOOK-TEST.yml
@@ -1,0 +1,34 @@
+name: PRE-COMMIT
+
+on:
+  push:
+    branches:
+      - master
+      - develop
+    tags:
+      - '*'
+  pull_request:
+    paths:
+      - .github/workflows/PRE-COMMIT-HOOK-TEST.yml
+      - .pre-commit-hooks.yaml
+      - e2e/pre-commit-hook/*
+      - package.json
+
+jobs:
+  hook-test:
+    runs-on: ubuntu-latest
+    name: Test Hook
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install pre-commit
+        run: |
+          python -m pip install pre-commit
+      - name: Test hooks
+        run: |
+          ./e2e/pre-commit-hook/test.sh

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: solhint
+  name: solhint
+  description: Lint Solidity files with Solhint
+  entry: solhint
+  files: \.sol$
+  language: node

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,5 +2,5 @@
   name: solhint
   description: Lint Solidity files with Solhint
   entry: solhint
-  files: \.sol$
+  types: ["solidity"]
   language: node

--- a/README.md
+++ b/README.md
@@ -210,6 +210,18 @@ Or disable all validations for a group of lines:
 ### Solhint has an official Docker Image
 Go to docker folder and follow [this](docker/docker.md) instructions.
 
+## pre-commit
+### Solhint can also be used as [pre-commit](https://pre-commit.com/) hook
+
+Replace `$GIT_TAG` with real tag:
+
+```YAML
+- repo: https://github.com/protofire/solhint
+  rev: $GIT_TAG
+  hooks:
+    - id: solhint
+```
+
 ## Documentation
 Related documentation you may find [here](https://protofire.github.io/solhint/).
 

--- a/e2e/pre-commit-hook/.solhint.json
+++ b/e2e/pre-commit-hook/.solhint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "solhint:recommended"
+}

--- a/e2e/pre-commit-hook/Counter.sol
+++ b/e2e/pre-commit-hook/Counter.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.26;
+
+contract Counter {
+    uint256 public number;
+
+    function setNumber(uint256 newNumber) public {
+        number = newNumber;
+    }
+
+    function increment() public {
+        number++;
+    }
+}

--- a/e2e/pre-commit-hook/test.sh
+++ b/e2e/pre-commit-hook/test.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -o errtrace -o nounset -o pipefail -o errexit
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
+# Create temp working directory for mock repo
+MOCK_REPO=$(mktemp -d)
+if [[ ! "$MOCK_REPO" || ! -d "$MOCK_REPO" ]]; then
+	echo "Could not create temp dir"
+	exit 1
+fi
+function cleanup {
+	echo "Deleting temp working directory $MOCK_REPO"
+	rm -rf "$MOCK_REPO"
+}
+
+trap cleanup EXIT
+
+# Filling the mock repo
+pushd "$MOCK_REPO" >/dev/null || exit 1
+git init --initial-branch=master
+git config user.email "test@example.com"
+git config user.name "pre-commit test"
+cp "$SCRIPT_DIR/.solhint.json" "$SCRIPT_DIR/Counter.sol" .
+git add .
+git commit -m "Initial commit"
+
+# Run pre-commit inside the mock repo while referencing the solhint directory, 
+# where the .pre-commit-hooks.yaml is located.
+pre-commit try-repo "$SCRIPT_DIR/../.." solhint --verbose --color=always --all-files

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "lint": "eslint .",
     "generate-rulesets": "node scripts/generate-rulesets.js && prettier --write conf/rulesets",
     "docs": "node scripts/generate-rule-docs.js",
-    "prepare": "husky install",
     "prepublishOnly": "npm run lint && npm run test && npm run generate-rulesets"
   },
   "bin": {


### PR DESCRIPTION
[pre-commit](https://pre-commit.com/) became pretty popular as framework to combine linters / code-formatters via [hooks](https://pre-commit.com/hooks.html) across different languages. It can be enabled as actual git hook or just used by running `pre-commit run -a`. pre-commit does its own dependency management (+cashing) and installs each hook into its own isolated folder.

This adds a `.pre-commit-hooks.yaml` (+ doc + test), which allows other projects to run Solhint via pre-commit.

Tested it also via my solhint fork with custom test tag, see https://github.com/dbast/sol-press/pull/16

pre-commit installs a hook by cloning the `repo`, checking out the specified git `rev` (=tag, branch, commit hash), parsing the .pre-commit-hooks.yaml and installing the hook (in case of node based hooks: run `npm pack` (produces a tarball + `npm install $tarball`). Installed hooks are cached based on the rev for later repeated runs.

Had to remove the `prepare` [script](https://docs.npmjs.com/cli/v10/using-npm/scripts) in package.json as that prevents `npm pack` from working with a plain node install (which is used by pre-commit during isolated hook installations). `prepare` is afaik not the right place to run `husky install`.