### PR TITLE
fix: typos in documentation files

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -4,7 +4,7 @@ layout:      "default"
 title:       "Rule Index of Solhint"
 ---
 
-## Best Practise Rules
+## Best Practice Rules
 
 | Rule Id                                                                  | Error                                                                                                                                      | Recommended  | Deprecated |
 | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ | ------------ | ---------- |
@@ -69,7 +69,7 @@ title:       "Rule Index of Solhint"
 
 | Rule Id                                                                     | Error                                                                                                                                  | Recommended  | Deprecated |
 | --------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ------------ | ---------- |
-| [comprehensive-interface](./rules/miscellaneous/comprehensive-interface.md) | Check that all public or external functions are override. This is iseful to make sure that the whole API is extracted in an interface. |              |            |
+| [comprehensive-interface](./rules/miscellaneous/comprehensive-interface.md) | Check that all public or external functions are override. This is useful to make sure that the whole API is extracted in an interface. |              |            |
 | [quotes](./rules/miscellaneous/quotes.md)                                   | Enforces the use of double or simple quotes as configured for string literals. Values must be 'single' or 'double'.                    | $~~~~~~~~$✔️ |            |
         
 


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected "Practise" to "Practice".
Corrected "iseful" to "useful".

Please review the changes and let me know if any additional changes are needed.