### PR TITLE
Fix typos and grammatical errors in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ## [5.0.1] - 2024-05-13
 ### BREAKING CHANGES (refer to v5.0.0)
-Fixed an issue on the returining values where only was evaluating the first report instead of all of them.
+Fixed an issue on the returning values where only was evaluating the first report instead of all of them.
 
 
 <br><br>
@@ -68,7 +68,7 @@ Thanks to [@juanpcapurro](https://github.com/juanpcapurro) for providing the cod
 - New Rule: Interface starts with `i` [#557](https://github.com/protofire/solhint/pull/557)
 
 #### Gas Consumption Rules
-- New Rule: [GC] Mutlitoken1155 rule [#541](https://github.com/protofire/solhint/pull/541)
+- New Rule: [GC] Multitoken1155 rule [#541](https://github.com/protofire/solhint/pull/541)
 - New Rule: [GC] Small strings check [#542](https://github.com/protofire/solhint/pull/542)
 - New Rule: [GC] Indexed events [#543](https://github.com/protofire/solhint/pull/543)
 - New Rule: [GC] Calldata parameters [#544](https://github.com/protofire/solhint/pull/544)
@@ -153,7 +153,7 @@ Thanks to [@juanpcapurro](https://github.com/juanpcapurro) for providing the cod
   
 ### Fixed
 - `foundry-test-functions` - Modified regex to include invariant and statefulFuzz tests [#484](https://github.com/protofire/solhint/pull/484)
-- `quotes` - To allow quotes inside double quotes and viceversa [#485](https://github.com/protofire/solhint/pull/485)
+- `quotes` - To allow quotes inside double quotes and vice versa [#485](https://github.com/protofire/solhint/pull/485)
 - `JSON` - Formatter returning JS object instead of standard json [#490](https://github.com/protofire/solhint/pull/490) 
 
 

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Or disable all validations for a group of lines:
 ### Style Guide Rules
 [Full list with all supported Style Guide Rules](docs/rules.md#style-guide-rules)
 ### Best Practices Rules
-[Full list with all supported Best Practices Rules](docs/rules.md#best-practise-rules)
+[Full list with all supported Best Practices Rules](docs/rules.md#best-practice-rules)
 
 ## Docker
 ### Solhint has an official Docker Image
@@ -257,7 +257,7 @@ Related documentation you may find [here](https://protofire.github.io/solhint/).
 
 The Solidity parser used is [`@solidity-parser/parser`](https://github.com/solidity-parser/parser).
 
-## Licence
+## License
 
 MIT
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -69,7 +69,7 @@ title:       "Rule Index of Solhint"
 
 | Rule Id                                                                     | Error                                                                                                                                  | Recommended  | Deprecated |
 | --------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ------------ | ---------- |
-| [comprehensive-interface](./rules/miscellaneous/comprehensive-interface.md) | Check that all public or external functions are override. This is iseful to make sure that the whole API is extracted in an interface. |              |            |
+| [comprehensive-interface](./rules/miscellaneous/comprehensive-interface.md) | Check that all public or external functions are overridden. This is useful to make sure that the whole API is extracted in an interface. |              |            |
 | [quotes](./rules/miscellaneous/quotes.md)                                   | Enforces the use of double or simple quotes as configured for string literals. Values must be 'single' or 'double'.                    | $~~~~~~~~$✔️ |            |
         
 


### PR DESCRIPTION

## Changes Made

### In `docs/rules.md`:
1. `iseful` → `useful`
2. `override` → `overridden`

### In `CHANGELOG.md`:
1. `returining` → `returning`
2. `viceversa` → `vice versa`
3. `Mutlitoken` → `Multitoken`

### In `README.md`:
1. `Licence` → `License`
2. `best-practise` → `best-practice`

## Explanation

These changes improve documentation quality and consistency by:

1. Correcting misspellings:
   - `iseful` was a typo of `useful`
   - `returining` was a typo of `returning`
   - `Mutlitoken` was a typo of `Multitoken`

2. Fixing grammatical constructions:
   - `override` → `overridden` (correct past participle form)
   - `viceversa` → `vice versa` (correct Latin phrase spelling)

3. Standardizing American English spelling:
   - `Licence` → `License` (American English standard)

4. Fixing technical terminology:
   - `best-practise` → `best-practice` (standard industry spelling)

These corrections enhance readability and maintain professional documentation standards, which is especially important for a linting tool that helps others write better code.