### PR TITLE
Fix Typographical Errors Update named-parameters-mapping.md

### DIFF
--- a/docs/rules/naming/named-parameters-mapping.md
+++ b/docs/rules/naming/named-parameters-mapping.md
@@ -12,7 +12,7 @@ title:       "named-parameters-mapping | Solhint"
 Solidity v0.8.18 introduced named parameters on the mappings definition.
 
 ## Options
-This rule accepts a string option of rule severity. Must be one of "error", "warn", "off". Default to warn.
+This rule accepts a string option of rule severity. Must be one of "error", "warn", "off". Defaults to warn.
 
 ### Example Config
 ```json
@@ -39,7 +39,7 @@ mapping(string name => uint256 balance) public users;
 mapping(address owner => mapping(address token => uint256 balance)) public tokenBalances;
 ```
 
-#### Main key of mapping is enforced. On nested mappings other naming are not necessary
+#### Main key of mapping is enforced. On nested mappings other names are not necessary
 
 ```solidity
 mapping(address owner => mapping(address => uint256)) public tokenBalances;
@@ -77,7 +77,7 @@ mapping(address token => uint256)) public tokenBalances;
 mapping(address => uint256 balance)) public tokenBalances;
 ```
 
-#### No MAIN KEY naming in nested mapping. Other naming are not enforced
+#### No MAIN KEY naming in nested mapping. Other names are not enforced
 
 ```solidity
 mapping(address => mapping(address token => uint256 balance)) public tokenBalances;


### PR DESCRIPTION
This update addresses a few typographical issues in the documentation of the `named-parameters-mapping` rule.

- **"Default to warn"** has been corrected to **"Defaults to warn"** to ensure proper grammar in the sentence.
- **"Other naming are not necessary"** has been updated to **"Other names are not necessary"** to use the correct plural form of "name."
- **"Other naming are not enforced"** has been revised to **"Other names are not enforced"** for the same reason.

These corrections improve the clarity and readability of the documentation, making it more consistent and easier for users to understand the rule details.