### PR TITLE
Fix: broken links in README.md and rules.md  

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://protofire.io/projects/solhint" target="_blank"><img src="solhint.png"></a>
+  <a href="https://protofire.io/solhint" target="_blank"><img src="solhint.png"></a>
 </p>
 <p align="center">
   By <a href="https://protofire.io/" target="_blank">Protofire</a>
@@ -16,7 +16,7 @@ https://coveralls.io/github/protofire/solhint?branch=master)
 This is an open source project for linting [Solidity](http://solidity.readthedocs.io/en/develop/) code. This project
 provides both **Security** and **Style Guide** validations.
 <br>
-[VISIT OUR WEBSITE](https://protofire.io/projects/solhint)<br>
+[VISIT OUR WEBSITE](https://protofire.io/solhint)<br>
 [JOIN OUR DISCORD SERVER](https://discord.gg/4TYGq3zpjs)
 <br>
 ## Installation

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -98,5 +98,5 @@ title:       "Rule Index of Solhint"
 
 ## References
 
-- [ConsenSys Guide for Smart Contracts](https://consensys.github.io/smart-contract-best-practices/recommendations/)
+- [ConsenSys Guide for Smart Contracts](https://consensys.github.io/smart-contract-best-practices/development-recommendations/)
 - [Solidity Style Guide](http://solidity.readthedocs.io/en/develop/style-guide.html)


### PR DESCRIPTION
### Changes introduced  
- Updated incorrect and outdated links in:  
  - `README.md`:  
    - Fixed project website link: `https://protofire.io/projects/solhint` → `https://protofire.io/solhint`.  
  - `docs/rules.md`:  
    - Updated ConsenSys guide link:  
      `https://consensys.github.io/smart-contract-best-practices/recommendations/` → `https://consensys.github.io/smart-contract-best-practices/development-recommendations/`. 
