### PR TITLE
Update use-in-app.md

### DIFF
--- a/docs/use-in-app.md
+++ b/docs/use-in-app.md
@@ -27,7 +27,7 @@ report.messages.forEach(curError => console.log(curError.message));
   **linter.processStr**:
    
    - Arguments:
-     - code {String} - Source code to validation
+     - code {String} - Source code for validation
      - config {Object} - Object representation of .solhint.json configuration
    - Returns: 
      - report {Report} - object that contains list of errors and warnings


### PR DESCRIPTION
Fix grammar in API documentation

Changes in docs/use-in-app.md:
- Old: Source code to validation
- New: Source code for validation

Why: Improves grammar by using correct preposition "for" instead of "to" when describing purpose.

