### PR TITLE
fix: rename camel case rules to pascal case

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ This option currently works on:
 - private-vars-underscore
 - payable-fallback
 - quotes
-- contract-name-camelcase
+- contract-name-capwords
 - avoid-suicide
   
 <br><br>


### PR DESCRIPTION
Rules named with camel-case were incorrectly named