### PR TITLE
fix: remove 'default' configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ First initialize a configuration file, if you don't have one:
 solhint --init
 ```
 
-This will create a `.solhint.json` file with the default rules enabled. Then run Solhint with one or more [Globs](https://en.wikipedia.org/wiki/Glob_(programming)) as arguments. For example, to lint all files inside `contracts` directory, you can do:
+This will create a `.solhint.json` file with the recommended rules enabled. Then run Solhint with one or more [Globs](https://en.wikipedia.org/wiki/Glob_(programming)) as arguments. For example, to lint all files inside `contracts` directory, you can do:
 
 ```sh
 solhint 'contracts/**/*.sol'
@@ -108,11 +108,12 @@ This file has the following format:
 ### Default 
 ```json
 {
-  "extends": "solhint:default"
+  "extends": "solhint:recommended"
 }
 ```
 ### Note
 The `solhint:default` configuration contains only two rules: max-line-length & no-console
+It is now deprecated since version 5.1.0
 <br><br>
 
 
@@ -139,9 +140,9 @@ additional-tests.sol
 
 ### Extendable rulesets
 
-The default rulesets provided by solhint are the following:
+The rulesets provided by solhint are the following:
 
-+ solhint:default
++ solhint:default (deprecated since version v5.1.0)
 + solhint:recommended
 
 Use one of these as the value for the "extends" property in your configuration file.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,7 +22,7 @@ format:
 
 ```json
   {
-    "extends": "solhint:default",
+    "extends": "solhint:recommended",
     "plugins": [],
     "rules": {
       "const-name-snakecase": "off",

--- a/docs/rules/best-practices/max-line-length.md
+++ b/docs/rules/best-practices/max-line-length.md
@@ -7,7 +7,7 @@ title:       "max-line-length | Solhint"
 # max-line-length
 ![Category Badge](https://img.shields.io/badge/-Best%20Practice%20Rules-informational)
 ![Default Severity Badge error](https://img.shields.io/badge/Default%20Severity-error-red)
-> The {"extends": "solhint:default"} property in a configuration file enables this rule.
+> The {"extends": "solhint:default"} property in a configuration file enables this rule. THIS IS DEPRECATED SINCE VERSION 5.1.0
 
 
 ## Description

--- a/docs/rules/best-practices/no-console.md
+++ b/docs/rules/best-practices/no-console.md
@@ -8,7 +8,7 @@ title:       "no-console | Solhint"
 ![Recommended Badge](https://img.shields.io/badge/-Recommended-brightgreen)
 ![Category Badge](https://img.shields.io/badge/-Best%20Practice%20Rules-informational)
 ![Default Severity Badge error](https://img.shields.io/badge/Default%20Severity-error-red)
-> The {"extends": "solhint:default"} property in a configuration file enables this rule.
+> The {"extends": "solhint:default"} property in a configuration file enables this rule. THIS IS DEPRECATED SINCE VERSION 5.1.0
 
 > The {"extends": "solhint:recommended"} property in a configuration file enables this rule.
 

--- a/scripts/generate-rule-docs.js
+++ b/scripts/generate-rule-docs.js
@@ -84,7 +84,7 @@ ${[
   categoryBadge(rule.meta.docs.category),
   defaultSeverityBadge(defaultSeverity),
   isDefault
-    ? '> The {"extends": "solhint:default"} property in a configuration file enables this rule.\n'
+    ? '> The {"extends": "solhint:default"} property in a configuration file enables this rule. THIS IS DEPRECATED SINCE VERSION 5.1.0\n'
     : '',
   isRecommended
     ? '> The {"extends": "solhint:recommended"} property in a configuration file enables this rule.\n'

--- a/solhint.js
+++ b/solhint.js
@@ -216,7 +216,7 @@ function processStdin(options) {
 function writeSampleConfigFile() {
   const configPath = '.solhint.json'
   const sampleConfig = `{
-  "extends": "solhint:default"
+  "extends": "solhint:recommended"
 }
 `
   if (!fs.existsSync(configPath)) {


### PR DESCRIPTION
The `solhint:default` configuration contains only two rules: max-line-length & no-console

Therefore we decided to remove and replace default behavior with the `recommended` config