### PR TITLE
Fix typos in code comments

### DIFF
--- a/lib/rules/gas-consumption/gas-increment-by-one.js
+++ b/lib/rules/gas-consumption/gas-increment-by-one.js
@@ -60,12 +60,12 @@ class GasIncrementByOne extends BaseChecker {
     const leftVar = this.extractVariableName(left)
     let rightValue
 
-    // asignment and operation
+    // assignment and operation
     if (operator === '+=' || operator === '-=') {
       rightValue = right.type === 'NumberLiteral' && parseInt(right.number) === 1
       return { result: leftVar && rightValue, varName: leftVar }
     }
-    // regular asignment
+    // regular assignment
     else if (operator === '=') {
       const rightVar = this.extractVariableName(right.left)
       rightValue =

--- a/lib/rules/naming/named-parameters-mapping.js
+++ b/lib/rules/naming/named-parameters-mapping.js
@@ -69,7 +69,7 @@ class NamedParametersMappingChecker extends BaseChecker {
     let isNested = false
     const variables = node.variables
     variables.forEach((variable) => {
-      // maybe the comparission to VariableDeclaration can be deleted
+      // maybe the comparison to VariableDeclaration can be deleted
       if (variable.type === 'VariableDeclaration' && variable.typeName.type === 'Mapping') {
         if (variable.typeName.valueType.type === 'Mapping') {
           // isNested mapping


### PR DESCRIPTION


This PR fixes two typos in code comments:

1. In `lib/rules/gas-consumption/gas-increment-by-one.js`, corrected the misspelling of "asignment" to the proper "assignment" in comments.

2. In `lib/rules/naming/named-parameters-mapping.js`, corrected the misspelling of "comparission" to the proper "comparison" in a comment.

These changes improve code readability and eliminate minor documentation errors.
