### PR TITLE
Fix Typo in Function Name

### DIFF
--- a/test/rules/best-practices/explicit-types.js
+++ b/test/rules/best-practices/explicit-types.js
@@ -3,7 +3,7 @@ const contractWith = require('../../common/contract-builder').contractWith
 const { assertErrorCount, assertNoErrors, assertErrorMessage } = require('../../common/asserts')
 const VAR_DECLARATIONS = require('../../fixtures/best-practices/explicit-types')
 
-const getZeroErrosObject = () => {
+const getZeroErrorsObject = () => {
   const zeroErrorsExplicit = {}
   const zeroErrorsImplicit = {}
   for (const key in VAR_DECLARATIONS) {


### PR DESCRIPTION


**Description:**  
This pull request corrects a typo in the function name `getZeroErrosObject`, renaming it to `getZeroErrorsObject` in the `test/rules/best-practices/explicit-types.js`