### PR TITLE
fix: correct encoding comment to UTF-8

### DIFF
--- a/solhint.js
+++ b/solhint.js
@@ -376,7 +376,7 @@ function writeStringToFile(data) {
   const cleanedData = data.replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, '')
 
   try {
-    fs.writeFileSync(fileName, cleanedData, 'utf-8') // Specify the encoding (UTF-16)
+    fs.writeFileSync(fileName, cleanedData, 'utf-8') // Specify the encoding (UTF-8)
     // console.log('File written successfully:', fileName)
   } catch (err) {
     console.error('Error writing to file:', err)


### PR DESCRIPTION
The writeStringToFile function was documenting “Specify the encoding (UTF-16)” 
but actually writes files as UTF-8. This updates the comment for accuracy.








