### PR TITLE
docs: update broken link

### DIFF
--- a/docs/rules/best-practices/constructor-syntax.md
+++ b/docs/rules/best-practices/constructor-syntax.md
@@ -32,5 +32,5 @@ This rule was introduced in [Solhint 1.2.0](https://github.com/protofire/solhint
 
 ## Resources
 - [Rule source](https://github.com/protofire/solhint/blob/master/lib/rules/deprecations/constructor-syntax.js)
-- [Document source](https://github.com/protofire/solhint/blob/master/docs/rules/deprecations/constructor-syntax.md)
+- [Document source](https://github.com/protofire/solhint/blob/master/docs/rules/best-practices/constructor-syntax.md)
 - [Test cases](https://github.com/protofire/solhint/blob/master/test/rules/deprecations/constructor-syntax.js)


### PR DESCRIPTION
I fixed a broken link.

Before:
![image](https://github.com/user-attachments/assets/d3ade24f-1d1c-42a1-b6e0-e4b8809db9dd)

After:
![image](https://github.com/user-attachments/assets/a49a0d8d-b03a-4521-9d5c-17758f702005)
