### PR TITLE
Fix typo in documentation and code comments

### DIFF
--- a/docs/rules/miscellaneous/quotes.md
+++ b/docs/rules/miscellaneous/quotes.md
@@ -36,7 +36,7 @@ This rule accepts an array of options:
 ```
 
 ### Notes
-- This rule allows to put a double quote inside single quote string and viceversa
+- This rule allows to put a double quote inside single quote string and vice versa
 
 ## Examples
 ### 👍 Examples of **correct** code for this rule

--- a/lib/rules/best-practices/explicit-types.js
+++ b/lib/rules/best-practices/explicit-types.js
@@ -84,7 +84,7 @@ class ExplicitTypesChecker extends BaseChecker {
       (config && config.getStringFromArray(ruleId, DEFAULT_OPTION)) || DEFAULT_OPTION
     this.isExplicit = this.configOption === 'explicit'
 
-    // if explicit, it will search for implicit and viceversa
+    // if explicit, it will search for implicit and vice versa
     if (this.isExplicit) {
       typesToSearch = IMPLICIT_TYPES
     } else {


### PR DESCRIPTION


---



## Description
This pull request corrects a minor typo by replacing "viceversa" with the proper form "vice versa" in both documentation and code comments.  


---