### PR TITLE
fix: remove `strip-ansi`

### DIFF
--- a/lib/formatters/stylish.js
+++ b/lib/formatters/stylish.js
@@ -4,7 +4,7 @@
  */
 
 const chalk = require('chalk')
-const stripAnsi = require('strip-ansi')
+const stripAnsi = require('util').stripVTControlCharacters
 const table = require('text-table')
 
 //------------------------------------------------------------------------------

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "solhint",
-  "version": "5.1.0",
+  "version": "6.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "solhint",
-      "version": "5.1.0",
+      "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
         "@solidity-parser/parser": "^0.20.0",
         "ajv": "^6.12.6",
+        "ajv-errors": "^1.0.1",
         "antlr4": "^4.13.1-patch-1",
         "ast-parents": "^0.0.1",
         "better-ajv-errors": "^2.0.2",
@@ -18,6 +19,7 @@
         "commander": "^10.0.0",
         "cosmiconfig": "^8.0.0",
         "fast-diff": "^1.2.0",
+        "fs-extra": "^11.1.0",
         "glob": "^8.0.3",
         "ignore": "^5.2.4",
         "js-yaml": "^4.1.0",
@@ -25,7 +27,6 @@
         "lodash": "^4.17.21",
         "pluralize": "^8.0.0",
         "semver": "^7.5.2",
-        "strip-ansi": "^6.0.1",
         "table": "^6.8.1",
         "text-table": "^0.2.0"
       },
@@ -33,7 +34,6 @@
         "solhint": "solhint.js"
       },
       "devDependencies": {
-        "ajv-errors": "^1.0.1",
         "assert": "^2.0.0",
         "chai": "^4.3.7",
         "coveralls": "^3.1.1",
@@ -42,7 +42,6 @@
         "eslint-config-prettier": "^8.6.0",
         "eslint-plugin-import": "^2.29.1",
         "eslint-plugin-prettier": "^4.2.1",
-        "fs-extra": "^11.1.0",
         "get-stream": "^6.0.0",
         "markdown-table": "^2.0.0",
         "mocha": "^10.2.0",
@@ -905,7 +904,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "ajv": ">=5.0.0"
@@ -2723,7 +2721,6 @@
       "version": "11.3.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
       "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
-      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -3020,8 +3017,7 @@
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
@@ -4033,7 +4029,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -6497,7 +6492,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
       "engines": {
         "node": ">= 10.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "lodash": "^4.17.21",
     "pluralize": "^8.0.0",
     "semver": "^7.5.2",
-    "strip-ansi": "^6.0.1",
     "table": "^6.8.1",
     "text-table": "^0.2.0",
     "fs-extra": "^11.1.0"


### PR DESCRIPTION
Replaces `strip-ansi` with built-in `stripVTControlCharacters` which is available since Node 16.11