### PR TITLE
fix: remove `fs-extra`

### DIFF
--- a/e2e/autofix-test.js
+++ b/e2e/autofix-test.js
@@ -566,10 +566,12 @@ function useFixture(dir) {
     const tmpDirContainer = os.tmpdir()
     this.testDirPath = path.join(tmpDirContainer, `solhint-tests-${dir}`)
 
-    fs.ensureDirSync(this.testDirPath)
-    fs.emptyDirSync(this.testDirPath)
+    fs.mkdirSync(this.testDirPath, { recursive: true })
+    for (const entry of fs.readdirSync(this.testDirPath)) {
+      fs.rmSync(path.join(this.testDirPath, entry), { recursive: true, force: true });
+    }
 
-    fs.copySync(fixturePath, this.testDirPath)
+    fs.cpSync(fixturePath, this.testDirPath, { recursive: true })
 
     shell.cd(this.testDirPath)
   })

--- a/e2e/autofix-test.js
+++ b/e2e/autofix-test.js
@@ -1,6 +1,6 @@
 const chai = require('chai')
 const { expect } = chai
-const fs = require('fs-extra')
+const fs = require('fs')
 const os = require('os')
 const path = require('path')
 const shell = require('shelljs')

--- a/e2e/formatters-test.js
+++ b/e2e/formatters-test.js
@@ -705,10 +705,12 @@ function useFixture(dir) {
     const tmpDirContainer = os.tmpdir()
     this.testDirPath = path.join(tmpDirContainer, `solhint-tests-${dir}`)
 
-    fs.ensureDirSync(this.testDirPath)
-    fs.emptyDirSync(this.testDirPath)
+    fs.mkdirSync(this.testDirPath, { recursive: true })
+    for (const entry of fs.readdirSync(this.testDirPath)) {
+      fs.rmSync(path.join(this.testDirPath, entry), { recursive: true, force: true });
+    }
 
-    fs.copySync(fixturePath, this.testDirPath)
+    fs.cpSync(fixturePath, this.testDirPath, { recursive: true })
 
     shell.cd(this.testDirPath)
   })

--- a/e2e/formatters-test.js
+++ b/e2e/formatters-test.js
@@ -1,6 +1,6 @@
 const chai = require('chai')
 const { expect } = chai
-const fs = require('fs-extra')
+const fs = require('fs')
 const shell = require('shelljs')
 const url = require('url')
 const os = require('os')

--- a/e2e/test.js
+++ b/e2e/test.js
@@ -478,9 +478,12 @@ function useFixtureFolder(ctx, dir) {
 
   ctx.testDirPath = testDirPath
 
-  fs.ensureDirSync(testDirPath)
-  fs.emptyDirSync(testDirPath)
-  fs.copySync(fixturePath, testDirPath)
+    fs.mkdirSync(testDirPath, { recursive: true })
+    for (const entry of fs.readdirSync(testDirPath)) {
+      fs.rmSync(path.join(testDirPath, entry), { recursive: true, force: true });
+    }
+
+    fs.cpSync(fixturePath, testDirPath, { recursive: true })
 
   shell.cd(testDirPath)
 }

--- a/e2e/test.js
+++ b/e2e/test.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai')
 const cp = require('child_process')
-const fs = require('fs-extra')
+const fs = require('fs')
 const getStream = require('get-stream')
 const os = require('os')
 const path = require('path')

--- a/lib/cache/cache-manager.js
+++ b/lib/cache/cache-manager.js
@@ -1,4 +1,4 @@
-const fs = require('fs-extra')
+const fs = require('fs')
 const crypto = require('crypto')
 const path = require('path')
 

--- a/lib/common/utils.js
+++ b/lib/common/utils.js
@@ -1,4 +1,4 @@
-const fs = require('fs-extra')
+const fs = require('fs')
 const path = require('path')
 
 const getLocFromIndex = (text, index) => {

--- a/lib/config/config-file.js
+++ b/lib/config/config-file.js
@@ -1,4 +1,4 @@
-const fs = require('fs-extra')
+const fs = require('fs')
 const path = require('path')
 const _ = require('lodash')
 const { cosmiconfigSync } = require('cosmiconfig')

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-const fs = require('fs-extra')
+const fs = require('fs')
 const path = require('path')
 const parser = require('@solidity-parser/parser')
 const glob = require('glob')

--- a/lib/index.js
+++ b/lib/index.js
@@ -100,7 +100,7 @@ function processFile(file, config, rootDir = process.cwd(), explicitConfigPath) 
   const { report, updatedCache } = processAndCache(file, finalConfig, cacheState)
 
   if (finalConfig.cache && updatedCache) {
-    fs.ensureDirSync(path.dirname(cachePath)) // make sure the directory exists
+    fs.mkdirSync(path.dirname(cachePath), { recursive: true }) // make sure the directory exists
     writeCache(cachePath, updatedCache)
   }
 
@@ -135,7 +135,7 @@ function processPath(pattern, config, rootDir = process.cwd(), explicitConfigPat
   }
 
   if (useCache) {
-    fs.ensureDirSync(path.dirname(cachePath)) // make sure the directory exists
+    fs.mkdirSync(path.dirname(cachePath), { recursive: true }) // make sure the directory exists
     writeCache(cachePath, updatedCache)
   }
 

--- a/lib/rules/miscellaneous/import-path-check.js
+++ b/lib/rules/miscellaneous/import-path-check.js
@@ -1,4 +1,4 @@
-const fs = require('fs-extra')
+const fs = require('fs')
 const path = require('path')
 const BaseChecker = require('../base-checker')
 const { severityDescription } = require('../../doc/utils')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "solhint",
-  "version": "5.1.0",
+  "version": "6.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "solhint",
-      "version": "5.1.0",
+      "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
         "@solidity-parser/parser": "^0.20.0",
         "ajv": "^6.12.6",
+        "ajv-errors": "^1.0.1",
         "antlr4": "^4.13.1-patch-1",
         "ast-parents": "^0.0.1",
         "better-ajv-errors": "^2.0.2",
@@ -33,7 +34,6 @@
         "solhint": "solhint.js"
       },
       "devDependencies": {
-        "ajv-errors": "^1.0.1",
         "assert": "^2.0.0",
         "chai": "^4.3.7",
         "coveralls": "^3.1.1",
@@ -42,7 +42,6 @@
         "eslint-config-prettier": "^8.6.0",
         "eslint-plugin-import": "^2.29.1",
         "eslint-plugin-prettier": "^4.2.1",
-        "fs-extra": "^11.1.0",
         "get-stream": "^6.0.0",
         "markdown-table": "^2.0.0",
         "mocha": "^10.2.0",
@@ -905,7 +904,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "ajv": ">=5.0.0"
@@ -2719,20 +2717,6 @@
         }
       ]
     },
-    "node_modules/fs-extra": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -4027,18 +4011,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/jsonpointer": {
@@ -6491,15 +6463,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/update-browserslist-db": {

--- a/package.json
+++ b/package.json
@@ -44,9 +44,9 @@
     "@solidity-parser/parser": "^0.20.0",
     "ajv": "^6.12.6",
     "ajv-errors": "^1.0.1",
-    "better-ajv-errors": "^2.0.2",
     "antlr4": "^4.13.1-patch-1",
     "ast-parents": "^0.0.1",
+    "better-ajv-errors": "^2.0.2",
     "chalk": "^4.1.2",
     "commander": "^10.0.0",
     "cosmiconfig": "^8.0.0",
@@ -60,8 +60,7 @@
     "semver": "^7.5.2",
     "strip-ansi": "^6.0.1",
     "table": "^6.8.1",
-    "text-table": "^0.2.0",
-    "fs-extra": "^11.1.0"
+    "text-table": "^0.2.0"
   },
   "devDependencies": {
     "assert": "^2.0.0",

--- a/scripts/generate-rule-docs.js
+++ b/scripts/generate-rule-docs.js
@@ -1,5 +1,5 @@
 #!env node
-const fs = require('fs-extra')
+const fs = require('fs')
 const { exec, mkdir } = require('shelljs')
 const semver = require('semver')
 const path = require('path')

--- a/scripts/generate-rulesets.js
+++ b/scripts/generate-rulesets.js
@@ -1,4 +1,4 @@
-const fs = require('fs-extra')
+const fs = require('fs')
 
 const { loadRules } = require('../lib/load-rules')
 

--- a/solhint.js
+++ b/solhint.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 const program = require('commander')
 const _ = require('lodash')
-const fs = require('fs-extra')
+const fs = require('fs')
 const process = require('process')
 const readline = require('readline')
 const chalk = require('chalk')

--- a/test/common/utils.js
+++ b/test/common/utils.js
@@ -1,4 +1,4 @@
-const fs = require('fs-extra')
+const fs = require('fs')
 const os = require('os')
 const path = require('path')
 

--- a/test/rules/miscellaneous/config-hierarchy.js
+++ b/test/rules/miscellaneous/config-hierarchy.js
@@ -1,4 +1,4 @@
-const fs = require('fs-extra')
+const fs = require('fs')
 const path = require('path')
 const os = require('os')
 const rimraf = require('rimraf')

--- a/test/rules/miscellaneous/import-path-check.js
+++ b/test/rules/miscellaneous/import-path-check.js
@@ -17,7 +17,7 @@ describe('import-path-check (mocked fs)', () => {
   }
 
   beforeEach(() => {
-    existsStub = sinon.stub(require('fs-extra'), 'existsSync').callsFake((filePath) => {
+    existsStub = sinon.stub(require('fs'), 'existsSync').callsFake((filePath) => {
       return currentFakeFileSystem.has(normalizePath(filePath))
     })
   })


### PR DESCRIPTION
None of the extra utilities of `fs-extra` are used in solhint so it can be safely removed