### PR TITLE
fix typo in comment check

### DIFF
--- a/lib/rules/best-practices/no-unused-import.js
+++ b/lib/rules/best-practices/no-unused-import.js
@@ -140,7 +140,7 @@ class NoUnusedImportsChecker extends BaseChecker {
         (t.type === 'LineComment' || t.type === 'BlockComment' || t.type === 'Keyword') &&
         t.value &&
         isDocComment(t.value) && // evita // @inheritdoc ...
-        /@inheritdoc\b/.test(t.value) // requiere @inheritdoc exacto (no "@ inheritdoc", etc.)
+        /@inheritdoc\b/.test(t.value) // require @inheritdoc exacto (no "@ inheritdoc", etc.)
     )
 
     inheritdocTokens.forEach(({ value }) => {


### PR DESCRIPTION

Fix typo in `no-unused-import` comment check

