### PR TITLE
removing console log from use-natspec path

### DIFF
--- a/lib/rules/best-practices/use-natspec.js
+++ b/lib/rules/best-practices/use-natspec.js
@@ -279,10 +279,6 @@ class UseNatspecChecker extends BaseChecker {
     const startOffset = node.range[0]
     const comments = getLeadingNatSpecComments(startOffset, this.tokens)
 
-    console.log('isPublicLike :>> ', isPublicLike)
-    console.log('comments.length :>> ', comments.length)
-    console.log('type :>> ', type)
-
     // check the function is not publicLike and has no tags, avoid checking
     // if it is internal or private and has natspec comments, check them
     if (!isPublicLike && comments.length === 0 && type === 'function') return


### PR DESCRIPTION
# solhint use-natspec debug console.log bug

## Issue

https://github.com/protofire/solhint/issues/734

## Bug Description

When the `use-natspec` rule is enabled, solhint 6.0.2 outputs debug console.log statements to stdout.

## Steps to Reproduce

1. Clone this repository
2. Install dependencies:
   ```bash
   npm install
   ```
3. Run solhint:
   ```bash
   npm run lint
   ```

## Expected Behavior

Solhint should only output linting warnings/errors:
```
src/Example.sol
  6:1  warning  Missing @author tag in contract 'Example'  use-natspec
  7:5  warning  Missing @notice tag in variable 'value'    use-natspec

✖ 2 problems (0 errors, 2 warnings)
```

## Actual Behavior

Debug output is printed to stdout before linting results:
```
isPublicLike :>>  false
comments.length :>>  2
type :>>  contract
isPublicLike :>>  false
comments.length :>>  0
type :>>  variable
isPublicLike :>>  true
comments.length :>>  2
type :>>  function
isPublicLike :>>  true
comments.length :>>  2
type :>>  function

src/Example.sol
  6:1  warning  Missing @author tag in contract 'Example'  use-natspec
  7:5  warning  Missing @notice tag in variable 'value'    use-natspec

✖ 2 problems (0 errors, 2 warnings)
```

## Environment

- solhint version: 6.0.2
- Node.js version: v22.x (tested)
- OS: macOS

## Root Cause

The file `node_modules/solhint/lib/rules/naming/use-natspec.js` contains debug `console.log` statements that were not removed before release.

## Workaround

Disable the `use-natspec` rule in `.solhint.json`:
```json
{
  "rules": {
    "use-natspec": "off"
  }
}
```