### PR TITLE
Add DAML-LF viability spike: Node/TypeScript DALF/DAR probe and reports

### DIFF
--- a/daml-lf-viability-spike/.gitignore
+++ b/daml-lf-viability-spike/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+output/
+*.log
+.DS_Store

--- a/daml-lf-viability-spike/LICENSE
+++ b/daml-lf-viability-spike/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/daml-lf-viability-spike/PUSH_TO_NEW_REPO.md
+++ b/daml-lf-viability-spike/PUSH_TO_NEW_REPO.md
@@ -1,0 +1,43 @@
+# Push this project to a new GitHub repository
+
+This folder is ready to be used as an independent repository.
+
+## 1) Create an empty GitHub repo
+
+Create a new repository in GitHub UI (without README/license/gitignore), for example:
+
+- `your-org/daml-lf-viability-spike`
+
+## 2) Initialize and push from this folder
+
+From `/workspace/solhint` run:
+
+```bash
+cd daml-lf-viability-spike
+rm -rf .git
+git init
+git add .
+git commit -m "Initial commit: DAML LF viability spike"
+git branch -M main
+git remote add origin git@github.com:<YOUR_ORG_OR_USER>/<YOUR_NEW_REPO>.git
+git push -u origin main
+```
+
+If you use HTTPS instead of SSH:
+
+```bash
+git remote add origin https://github.com/<YOUR_ORG_OR_USER>/<YOUR_NEW_REPO>.git
+```
+
+## 3) First run in the new repo
+
+```bash
+npm install
+npm run probe -- <input.dar|input.dalf> --proto <path/to/official/daml-lf.proto>
+```
+
+## Notes
+
+- Output defaults to `./output`.
+- Required deps are declared in `package.json`.
+- This project is intentionally a **research spike**, not a linter engine.

--- a/daml-lf-viability-spike/README.md
+++ b/daml-lf-viability-spike/README.md
@@ -1,0 +1,77 @@
+# DAML-LF Viability Spike (Canton)
+
+A standalone TypeScript/Node.js research project to validate whether `.dalf` / `.dar` artifacts expose enough structured information to build a visitor-based static analyzer for DAML smart contracts.
+
+## Goal
+
+Before implementing any lint architecture, this repo focuses on evidence:
+
+- decode DALF with `protobufjs` (no JVM path),
+- dump raw decoded structures,
+- extract templates/choices/signatories/observers/keys/interfaces,
+- evaluate source-location quality.
+
+## Repository layout
+
+```text
+.
+├── LICENSE
+├── README.md
+├── package.json
+├── tsconfig.json
+├── src/
+│   └── dalf_probe.ts
+├── docs/
+│   └── findings.md
+└── output/
+```
+
+## Requirements
+
+- Node.js >= 18
+- Local official Daml-LF protobuf schema (`.proto` file)
+- A real `.dalf` or `.dar` input artifact
+
+## Install
+
+```bash
+npm install
+```
+
+## Usage
+
+```bash
+npm run probe -- <input.dar|input.dalf> --proto <path/to/official/daml-lf.proto> [--out-dir output]
+```
+
+Direct Node execution:
+
+```bash
+node src/dalf_probe.ts <input.dar|input.dalf> --proto <path/to/official/daml-lf.proto> [--out-dir output]
+```
+
+## Outputs
+
+For each DALF analyzed:
+
+- `*.decoded.json` — raw protobuf decode (no assumptions)
+- `*.constructs.json` — extracted construct buckets + location quality
+- `*.findings.md` — binary answers and blocker summary
+
+Global:
+
+- `summary.json` — analyzed DALFs and output paths
+
+## Scripts
+
+- `npm run probe -- ...` : run spike via ts-node
+- `npm run probe:node -- ...` : run script via node runtime
+- `npm run check` : type-check project
+- `npm run build` : compile TypeScript to `dist/`
+- `npm run clean` : clean generated artifacts
+
+## Notes
+
+- This repo does **not** implement lint rules yet.
+- If protobuf schema/version mismatches happen, inspect decode attempt logs in failures.
+- Source location fidelity must be validated manually against original `.daml` files.

--- a/daml-lf-viability-spike/docs/findings.md
+++ b/daml-lf-viability-spike/docs/findings.md
@@ -1,0 +1,41 @@
+# DAML-LF protobufjs feasibility spike
+
+This folder now contains an upgraded probe script (`dalf_probe.ts`) that combines:
+
+- strict decode-first flow from the initial spike,
+- richer extraction/report ideas from your reference script,
+- and explicit handling for DALF schema/version ambiguity.
+
+## What changed in the upgraded script
+
+1. **Decode strategies are now layered**:
+   - direct decode as `ArchivePayload`,
+   - or `Archive -> payload -> ArchivePayload/Package` fallback.
+2. **DAR handling improved**:
+   - all `.dalf` entries are extracted,
+   - likely project DALF is prioritized over stdlib-like entries.
+3. **Construct extraction now includes richer summaries**:
+   - template summaries (name/module/fields/signatory+observer expr shape),
+   - choice summaries (consuming, controller/observer expr shape, return type hint),
+   - raw structures are still preserved for every construct class.
+4. **Source-location quality analysis added**:
+   - counts original `.daml` references vs internal/generated vs missing file refs,
+   - outputs a sample set for manual line/column cross-checking.
+5. **Per-DALF markdown report generated automatically**:
+   - answers the binary research questions,
+   - includes a manual verification checklist for location fidelity.
+
+## Output files
+
+For each analyzed DALF the script writes:
+
+- `*.decoded.json`
+- `*.constructs.json`
+- `*.findings.md`
+- `summary.json`
+
+## Important constraints still true
+
+- The script still requires local installation of `protobufjs` + `adm-zip`.
+- The script still requires a local official Daml-LF `.proto` via `--proto`.
+- Final truth about location accuracy requires real `.dalf` + matching `.daml` source and manual cross-check.

--- a/daml-lf-viability-spike/package.json
+++ b/daml-lf-viability-spike/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "daml-lf-viability-spike",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Research spike to validate Daml-LF DALF/DAR decode viability for static analysis in Node.js.",
+  "license": "MIT",
+  "type": "module",
+  "main": "dist/dalf_probe.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "clean": "rimraf dist output",
+    "probe": "ts-node src/dalf_probe.ts",
+    "probe:node": "node src/dalf_probe.ts",
+    "check": "tsc -p tsconfig.json --noEmit"
+  },
+  "keywords": [
+    "daml",
+    "dalf",
+    "dar",
+    "protobuf",
+    "static-analysis",
+    "canton"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "adm-zip": "^0.5.16",
+    "protobufjs": "^7.4.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.13.10",
+    "rimraf": "^6.0.1",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.8.2"
+  }
+}

--- a/daml-lf-viability-spike/src/dalf_probe.ts
+++ b/daml-lf-viability-spike/src/dalf_probe.ts
@@ -1,0 +1,381 @@
+#!/usr/bin/env node
+import fs from 'node:fs'
+import path from 'node:path'
+
+type AnyObject = Record<string, any>
+
+interface Args {
+  input?: string
+  proto?: string
+  outDir: string
+}
+
+interface LocatedRaw {
+  path: string
+  raw: AnyObject
+  location: AnyObject | null
+}
+
+// Parse CLI arguments for input artifact, protobuf schema path, and output directory.
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = { outDir: 'output' }
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i]
+    if (token === '--proto') args.proto = argv[++i]
+    else if (token === '--out-dir') args.outDir = argv[++i]
+    else if (!args.input) args.input = token
+    else throw new Error(`Unknown extra argument: ${token}`)
+  }
+  return args
+}
+
+function ensureDir(dir: string) {
+  fs.mkdirSync(dir, { recursive: true })
+}
+
+async function loadDependencies() {
+  // Lazy runtime import keeps startup lightweight and gives a clear install message
+  // when this script is copied into a fresh environment.
+  try {
+    const protobufjs = await import('protobufjs')
+    const admZip = await import('adm-zip')
+    return { protobufjs, AdmZip: (admZip as any).default ?? admZip }
+  } catch (err) {
+    throw new Error(`Missing required dependencies. Install with: npm i protobufjs adm-zip\n${(err as Error).message}`)
+  }
+}
+
+function collectDalfFromInput(inputPath: string, AdmZip: any): Array<{ name: string; bytes: Buffer }> {
+  const ext = path.extname(inputPath).toLowerCase()
+  if (ext === '.dalf') return [{ name: path.basename(inputPath), bytes: fs.readFileSync(inputPath) }]
+  if (ext !== '.dar') throw new Error(`Unsupported extension: ${ext}. Expected .dar or .dalf`)
+
+  // DAR files are zip archives that may contain multiple DALFs.
+  // We return all DALFs, sorted so likely project payloads are analyzed first.
+  const zip = new AdmZip(inputPath)
+  const dalfEntries = zip.getEntries().filter((entry: any) => !entry.isDirectory && entry.entryName.endsWith('.dalf'))
+  if (dalfEntries.length === 0) throw new Error(`No .dalf entries found in DAR ${inputPath}`)
+
+  const scored = dalfEntries
+    .map((entry: any) => {
+      const name = entry.entryName
+      const penalty = ['daml-stdlib', 'daml-prim', 'daml-script', 'ghc', 'da/'].reduce(
+        (sum, marker) => sum + (name.toLowerCase().includes(marker) ? 1 : 0),
+        0,
+      )
+      return { entry, penalty }
+    })
+    .sort((a, b) => a.penalty - b.penalty)
+
+  return scored.map(({ entry }) => ({ name: entry.entryName, bytes: entry.getData() }))
+}
+
+function safeToObject(type: any, message: any): AnyObject {
+  return type.toObject(message, {
+    longs: String,
+    enums: String,
+    defaults: false,
+    oneofs: true,
+    arrays: true,
+    objects: true,
+  })
+}
+
+const archiveCandidates = [
+  'com.daml.daml_lf_dev.DamlLf.Archive',
+  'com.daml.daml_lf_dev.DamlLf1.Archive',
+  'com.daml.daml_lf_1.DamlLf.Archive',
+  'com.daml.daml_lf_1.DamlLf1.Archive',
+]
+const payloadCandidates = [
+  'com.daml.daml_lf_dev.DamlLf.ArchivePayload',
+  'com.daml.daml_lf_dev.DamlLf1.ArchivePayload',
+  'com.daml.daml_lf_1.DamlLf.ArchivePayload',
+  'com.daml.daml_lf_1.DamlLf1.ArchivePayload',
+]
+const packageCandidates = [
+  'com.daml.daml_lf_dev.DamlLf.Package',
+  'com.daml.daml_lf_dev.DamlLf1.Package',
+  'com.daml.daml_lf_1.DamlLf.Package',
+  'com.daml.daml_lf_1.DamlLf1.Package',
+]
+
+// Resolve whichever candidate protobuf messages exist in the loaded schema.
+// This supports small package-name differences across Daml-LF versions.
+function lookupTypes(root: any, candidates: string[]) {
+  return candidates
+    .map((name) => {
+      try {
+        return { name, type: root.lookupType(name) }
+      } catch {
+        return null
+      }
+    })
+    .filter(Boolean) as Array<{ name: string; type: any }>
+}
+
+function tryDecodeWithType(name: string, type: any, bytes: Buffer): { name: string; decoded: AnyObject } | null {
+  try {
+    return { name, decoded: safeToObject(type, type.decode(bytes)) }
+  } catch {
+    return null
+  }
+}
+
+// Decode using multiple strategies and record all failed attempts for debugging.
+function decodeDalf(root: any, bytes: Buffer) {
+  const payloadTypes = lookupTypes(root, payloadCandidates)
+  const archiveTypes = lookupTypes(root, archiveCandidates)
+  const packageTypes = lookupTypes(root, packageCandidates)
+
+  const attempts: string[] = []
+
+  for (const p of payloadTypes) {
+    const decoded = tryDecodeWithType(p.name, p.type, bytes)
+    if (decoded) return { strategy: `direct:${p.name}`, decoded: decoded.decoded, attempts }
+    attempts.push(`fail direct ${p.name}`)
+  }
+
+  for (const a of archiveTypes) {
+    const archiveDecoded = tryDecodeWithType(a.name, a.type, bytes)
+    if (!archiveDecoded) {
+      attempts.push(`fail archive ${a.name}`)
+      continue
+    }
+
+    const payload = archiveDecoded.decoded.payload
+    if (!payload) {
+      attempts.push(`archive ${a.name} had no payload field`) // useful debug signal
+      continue
+    }
+
+    const payloadBytes = Buffer.from(payload)
+    for (const p of payloadTypes) {
+      const decodedPayload = tryDecodeWithType(p.name, p.type, payloadBytes)
+      if (decodedPayload) {
+        return {
+          strategy: `archive:${a.name} -> payload:${p.name}`,
+          decoded: {
+            archive: archiveDecoded.decoded,
+            payload: decodedPayload.decoded,
+          },
+          attempts,
+        }
+      }
+      attempts.push(`fail payload ${p.name} after ${a.name}`)
+    }
+
+    for (const p of packageTypes) {
+      const decodedPackage = tryDecodeWithType(p.name, p.type, payloadBytes)
+      if (decodedPackage) {
+        return {
+          strategy: `archive:${a.name} -> package:${p.name}`,
+          decoded: {
+            archive: archiveDecoded.decoded,
+            pkg: decodedPackage.decoded,
+          },
+          attempts,
+        }
+      }
+      attempts.push(`fail package ${p.name} after ${a.name}`)
+    }
+  }
+
+  throw new Error(`Unable to decode DALF with loaded protobuf types. Attempts: ${attempts.join(' | ')}`)
+}
+
+function walk(node: any, visitor: (value: AnyObject, pathBits: string[]) => void, pathBits: string[] = []) {
+  if (Array.isArray(node)) return node.forEach((item, idx) => walk(item, visitor, [...pathBits, String(idx)]))
+  if (!node || typeof node !== 'object') return
+  visitor(node as AnyObject, pathBits)
+  Object.entries(node).forEach(([key, value]) => walk(value, visitor, [...pathBits, key]))
+}
+
+// Normalize location access because objects may expose `location` or `loc`.
+function pickLocation(raw: AnyObject): AnyObject | null {
+  if (raw.location && typeof raw.location === 'object') return raw.location
+  if (raw.loc && typeof raw.loc === 'object') return raw.loc
+  return null
+}
+
+// Report expression shape by top-level keys only (spike-level granularity).
+function exprShape(node: unknown): string {
+  if (!node || typeof node !== 'object') return 'missing'
+  const keys = Object.keys(node as AnyObject).filter((k) => k !== 'location')
+  return keys.join('|') || 'empty'
+}
+
+// Summarize source-location quality signals for manual cross-checking.
+function analyzeLocationQuality(locationNodes: LocatedRaw[]) {
+  const details = locationNodes.map((node) => {
+    const loc = node.location ?? {}
+    const file = loc.file || loc.filename || loc.moduleFilename || loc.source || null
+    const range = loc.range || {}
+    const line = range.startLine ?? loc.startLine ?? null
+    const col = range.startCol ?? loc.startCol ?? null
+
+    let fileKind = 'absent'
+    if (typeof file === 'string' && file.length > 0) {
+      if (file.endsWith('.daml')) fileKind = 'original_daml'
+      else if (file.includes('daml') || file.includes('DA.')) fileKind = 'internal_or_generated'
+      else fileKind = 'unknown'
+    }
+
+    return {
+      path: node.path,
+      file,
+      line,
+      col,
+      fileKind,
+      raw: node.location,
+    }
+  })
+
+  return {
+    exists: details.length > 0,
+    total: details.length,
+    originalDamlRefs: details.filter((d) => d.fileKind === 'original_daml').length,
+    internalRefs: details.filter((d) => d.fileKind === 'internal_or_generated').length,
+    missingFileRefs: details.filter((d) => d.fileKind === 'absent').length,
+    samples: details.slice(0, 30),
+  }
+}
+
+// Heuristic extraction pass: collect raw candidates without assuming strict schema fields.
+function extractConstructs(decoded: AnyObject) {
+  const out = {
+    templates: [] as LocatedRaw[],
+    choices: [] as LocatedRaw[],
+    signatories: [] as LocatedRaw[],
+    observers: [] as LocatedRaw[],
+    contractKeys: [] as LocatedRaw[],
+    interfaces: [] as LocatedRaw[],
+    sourceLocations: [] as LocatedRaw[],
+  }
+
+  // Traverse all nodes and bucket matches by shape/path hints.
+  walk(decoded, (raw, pathBits) => {
+    const keys = Object.keys(raw)
+    const lower = keys.map((k) => k.toLowerCase())
+    const pathText = pathBits.join('.')
+    const located = { path: pathText, raw, location: pickLocation(raw) }
+
+    if ((lower.includes('signatories') && lower.includes('choices')) || pathText.toLowerCase().includes('template')) out.templates.push(located)
+    if (lower.includes('consuming') || lower.includes('controllers')) out.choices.push(located)
+    if (lower.includes('signatories')) out.signatories.push({ ...located, raw: raw.signatories ?? raw })
+    if (lower.includes('observers')) out.observers.push({ ...located, raw: raw.observers ?? raw })
+    if (lower.includes('key') || lower.includes('maintainers')) {
+      if (pathText.toLowerCase().includes('key')) out.contractKeys.push(located)
+    }
+    if (pathText.toLowerCase().includes('interface') || lower.includes('methods') || lower.includes('requires')) out.interfaces.push(located)
+
+    if (
+      lower.includes('location') ||
+      lower.includes('modulefilename') ||
+      lower.includes('startline') ||
+      lower.includes('start_line')
+    ) {
+      out.sourceLocations.push(located)
+    }
+  })
+
+  const choiceSummary = out.choices.map((c) => ({
+    path: c.path,
+    name: c.raw.name ?? c.raw.nameInternedStr ?? '(unknown)',
+    consuming: c.raw.consuming ?? null,
+    controllerExpr: exprShape(c.raw.controllers),
+    observerExpr: exprShape(c.raw.observers),
+    returnTypeExpr: exprShape(c.raw.retType ?? c.raw.returnType),
+    raw: c.raw,
+    location: c.location,
+  }))
+
+  const templateSummary = out.templates.map((t) => ({
+    path: t.path,
+    name: t.raw.name ?? t.raw.tycon ?? '(unknown)',
+    module: t.raw.module ?? null,
+    fields: t.raw.fields ?? t.raw.record?.fields ?? null,
+    signatoryExpr: exprShape(t.raw.signatories),
+    observerExpr: exprShape(t.raw.observers),
+    raw: t.raw,
+    location: t.location,
+  }))
+
+  const locationQuality = analyzeLocationQuality(out.sourceLocations)
+
+  return {
+    found: Object.fromEntries(Object.entries(out).map(([k, v]) => [k, v.length > 0])),
+    counts: Object.fromEntries(Object.entries(out).map(([k, v]) => [k, v.length])),
+    templates: templateSummary,
+    choices: choiceSummary,
+    signatories: out.signatories,
+    observers: out.observers,
+    contractKeys: out.contractKeys,
+    interfaces: out.interfaces,
+    sourceLocations: out.sourceLocations,
+    sourceLocationQuality: locationQuality,
+  }
+}
+
+function renderFindingsReport(inputName: string, decodeStrategy: string, constructs: AnyObject) {
+  const templatesFound = constructs.counts.templates > 0 ? 'Yes' : 'No'
+  const choicesFound = constructs.counts.choices > 0 ? 'Yes' : 'No'
+  const signatoryReadability = constructs.signatories.some((s: any) => String(exprShape(s.raw)).includes('abs'))
+    ? 'Lambda'
+    : constructs.counts.signatories > 0
+      ? 'Structured'
+      : 'Mixed'
+  const loc = constructs.sourceLocationQuality
+
+  return `# DAML-LF Spike Findings\n\n- Input: ${inputName}\n- Decode strategy: ${decodeStrategy}\n\n## Answers\n\n1. Is the Daml-LF protobuf decodable with protobufjs without a JVM?\n   - Yes (for this sample with strategy: ${decodeStrategy}).\n2. Are template and choice definitions present as structured data?\n   - ${templatesFound === 'Yes' || choicesFound === 'Yes' ? 'Partially' : 'No'} (templates=${templatesFound}, choices=${choicesFound}).\n3. Are signatory and controller expressions readable as structured data or opaque lambda expressions?\n   - ${signatoryReadability}.\n4. Do source locations exist and point to original .daml source with accurate line/column?\n   - ${loc.exists ? 'Partially' : 'No'} (locations=${loc.total}, originalDamlRefs=${loc.originalDamlRefs}, internalRefs=${loc.internalRefs}, missingFileRefs=${loc.missingFileRefs}).\n5. What is the actual recommended input pipeline?\n   - .dalf directly (or .dar -> .dalf extraction) with protobufjs decode and post-processing over raw JSON.\n6. What are the real blockers for building a visitor-based linter on top of this?\n   - Schema/version drift between DALF and protobuf definitions.\n   - Potentially lambda-heavy signatory/controller expressions requiring expression visitor logic.\n   - Source location fidelity may be partial and needs manual verification against original .daml files.\n\n## Manual line/column validation checklist\n\n- Pick entries from \`*.constructs.json -> sourceLocationQuality.samples\`.\n- Open corresponding original \`.daml\` file and verify line/column points to expected construct.\n- Record mismatches if location appears module-only or generated/internal.\n`
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2))
+  if (!args.input) throw new Error('Usage: node src/dalf_probe.ts <input.dar|input.dalf> --proto <path/to/proto> [--out-dir dir]')
+  if (!args.proto || !fs.existsSync(args.proto)) throw new Error('Missing --proto path. Point to official Daml-LF .proto.')
+  if (!fs.existsSync(args.input)) throw new Error(`Input not found: ${args.input}`)
+
+  const deps = await loadDependencies()
+  ensureDir(args.outDir)
+
+  // Load official Daml-LF protobuf schema from local path.
+  const root = await deps.protobufjs.load(args.proto)
+  const dalfs = collectDalfFromInput(args.input, deps.AdmZip)
+  const summary: AnyObject[] = []
+
+  // Analyze every DALF independently to avoid coupling failures across entries.
+  for (const dalf of dalfs) {
+    const decoded = decodeDalf(root, dalf.bytes)
+    const constructs = extractConstructs(decoded.decoded)
+
+    const base = dalf.name.replace(/[^a-zA-Z0-9_.-]/g, '_')
+    const decodedPath = path.join(args.outDir, `${base}.decoded.json`)
+    const constructsPath = path.join(args.outDir, `${base}.constructs.json`)
+    const reportPath = path.join(args.outDir, `${base}.findings.md`)
+
+    fs.writeFileSync(decodedPath, JSON.stringify(decoded, null, 2))
+    fs.writeFileSync(constructsPath, JSON.stringify(constructs, null, 2))
+    fs.writeFileSync(reportPath, renderFindingsReport(dalf.name, decoded.strategy, constructs))
+
+    summary.push({
+      dalf: dalf.name,
+      decodeStrategy: decoded.strategy,
+      decodedPath,
+      constructsPath,
+      reportPath,
+      found: constructs.found,
+    })
+  }
+
+  const summaryPath = path.join(args.outDir, 'summary.json')
+  fs.writeFileSync(summaryPath, JSON.stringify(summary, null, 2))
+  console.log(`Wrote ${summary.length} DALF analysis result(s) into ${args.outDir}`)
+  console.log(`Summary: ${summaryPath}`)
+}
+
+main().catch((err) => {
+  console.error('[dalf-probe] fatal:', err.message)
+  process.exitCode = 1
+})

--- a/daml-lf-viability-spike/tsconfig.json
+++ b/daml-lf-viability-spike/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/research/daml-lf/README.md
+++ b/research/daml-lf/README.md
@@ -1,0 +1,108 @@
+# DAML-LF viability spike (Canton-focused)
+
+This folder contains a **research spike** to validate whether DALF artifacts contain enough structured information to support a static analyzer for DAML contracts running on Canton.
+
+> This is intentionally **not** a linter engine yet. It is an evidence-gathering tool.
+
+## What this spike validates
+
+1. Can `.dalf` / `.dar` be decoded in Node.js via `protobufjs` (no JVM runtime)?
+2. Are templates, choices, signatories, observers, keys, and interfaces present as structured nodes?
+3. Are source locations available and are they useful for mapping back to `.daml` files?
+4. What concrete blockers exist for a visitor-based analyzer?
+
+## Files
+
+- `dalf_probe.ts` — main probe script.
+- `findings.md` — high-level notes for this spike iteration.
+- output directory (generated):
+  - `*.decoded.json` — raw decoded protobuf object (no filtering assumptions).
+  - `*.constructs.json` — extracted semantic buckets + source-location quality signals.
+  - `*.findings.md` — per-DALF report with binary answers.
+  - `summary.json` — list of analyzed DALFs and output paths.
+
+## Installation (developer setup)
+
+Use Node.js 18+ (22+ recommended).
+
+Install required runtime deps:
+
+```bash
+npm i protobufjs adm-zip
+```
+
+Install dev tooling for TypeScript execution (if your repo does not already include it):
+
+```bash
+npm i -D typescript ts-node @types/node
+```
+
+## Suggested package.json snippet
+
+If you want to run this as part of a standalone spike package, add scripts like:
+
+```json
+{
+  "scripts": {
+    "daml:probe": "ts-node research/daml-lf/dalf_probe.ts",
+    "daml:probe:node": "node research/daml-lf/dalf_probe.ts"
+  },
+  "dependencies": {
+    "adm-zip": "^0.5.16",
+    "protobufjs": "^7.4.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.6.0"
+  }
+}
+```
+
+## Usage
+
+```bash
+node research/daml-lf/dalf_probe.ts <input.dar|input.dalf> --proto <path/to/official/daml-lf.proto> [--out-dir research/daml-lf/output]
+```
+
+Example:
+
+```bash
+node research/daml-lf/dalf_probe.ts ./sample.dar --proto ./proto/daml_lf.proto --out-dir ./research/daml-lf/output
+```
+
+## Decode strategy implemented
+
+The probe does not assume a single wrapper shape. It tries:
+
+1. direct decode as `ArchivePayload`.
+2. decode as `Archive`, then decode `archive.payload` as:
+   - `ArchivePayload`, then
+   - `Package`.
+
+This helps when DALF versions/wrappers differ.
+
+## How to interpret results
+
+- Start with `summary.json`.
+- Open `*.findings.md` to read binary answers and blockers.
+- Inspect `*.constructs.json`:
+  - `found` + `counts` show discovered construct categories.
+  - `templates` and `choices` include expression shape hints.
+  - `sourceLocationQuality` indicates whether file refs look like original `.daml` files.
+- If location refs look plausible, manually cross-check line/column against source.
+
+## Known limitations
+
+- Protobuf schema/version mismatch can produce partial or failed decode.
+- Expression fields (signatory/controller/observer) may be lambda-heavy and require AST traversal.
+- Location data may be module-level or generated/internal instead of direct source file paths.
+
+## Next step after successful viability
+
+If outputs are consistently good across real Canton-targeted DARs:
+
+1. Define a typed IR for Template/Choice/Expr/Location.
+2. Build a visitor over decoded expression trees.
+3. Add first structural rules (presence/shape checks) before semantic rules.
+4. Add robust source mapping strategy for diagnostics.

--- a/research/daml-lf/dalf_probe.ts
+++ b/research/daml-lf/dalf_probe.ts
@@ -1,0 +1,381 @@
+#!/usr/bin/env node
+import fs from 'node:fs'
+import path from 'node:path'
+
+type AnyObject = Record<string, any>
+
+interface Args {
+  input?: string
+  proto?: string
+  outDir: string
+}
+
+interface LocatedRaw {
+  path: string
+  raw: AnyObject
+  location: AnyObject | null
+}
+
+// Parse CLI arguments for input artifact, protobuf schema path, and output directory.
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = { outDir: 'research/daml-lf/output' }
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i]
+    if (token === '--proto') args.proto = argv[++i]
+    else if (token === '--out-dir') args.outDir = argv[++i]
+    else if (!args.input) args.input = token
+    else throw new Error(`Unknown extra argument: ${token}`)
+  }
+  return args
+}
+
+function ensureDir(dir: string) {
+  fs.mkdirSync(dir, { recursive: true })
+}
+
+async function loadDependencies() {
+  // Lazy runtime import keeps startup lightweight and gives a clear install message
+  // when this script is copied into a fresh environment.
+  try {
+    const protobufjs = await import('protobufjs')
+    const admZip = await import('adm-zip')
+    return { protobufjs, AdmZip: (admZip as any).default ?? admZip }
+  } catch (err) {
+    throw new Error(`Missing required dependencies. Install with: npm i protobufjs adm-zip\n${(err as Error).message}`)
+  }
+}
+
+function collectDalfFromInput(inputPath: string, AdmZip: any): Array<{ name: string; bytes: Buffer }> {
+  const ext = path.extname(inputPath).toLowerCase()
+  if (ext === '.dalf') return [{ name: path.basename(inputPath), bytes: fs.readFileSync(inputPath) }]
+  if (ext !== '.dar') throw new Error(`Unsupported extension: ${ext}. Expected .dar or .dalf`)
+
+  // DAR files are zip archives that may contain multiple DALFs.
+  // We return all DALFs, sorted so likely project payloads are analyzed first.
+  const zip = new AdmZip(inputPath)
+  const dalfEntries = zip.getEntries().filter((entry: any) => !entry.isDirectory && entry.entryName.endsWith('.dalf'))
+  if (dalfEntries.length === 0) throw new Error(`No .dalf entries found in DAR ${inputPath}`)
+
+  const scored = dalfEntries
+    .map((entry: any) => {
+      const name = entry.entryName
+      const penalty = ['daml-stdlib', 'daml-prim', 'daml-script', 'ghc', 'da/'].reduce(
+        (sum, marker) => sum + (name.toLowerCase().includes(marker) ? 1 : 0),
+        0,
+      )
+      return { entry, penalty }
+    })
+    .sort((a, b) => a.penalty - b.penalty)
+
+  return scored.map(({ entry }) => ({ name: entry.entryName, bytes: entry.getData() }))
+}
+
+function safeToObject(type: any, message: any): AnyObject {
+  return type.toObject(message, {
+    longs: String,
+    enums: String,
+    defaults: false,
+    oneofs: true,
+    arrays: true,
+    objects: true,
+  })
+}
+
+const archiveCandidates = [
+  'com.daml.daml_lf_dev.DamlLf.Archive',
+  'com.daml.daml_lf_dev.DamlLf1.Archive',
+  'com.daml.daml_lf_1.DamlLf.Archive',
+  'com.daml.daml_lf_1.DamlLf1.Archive',
+]
+const payloadCandidates = [
+  'com.daml.daml_lf_dev.DamlLf.ArchivePayload',
+  'com.daml.daml_lf_dev.DamlLf1.ArchivePayload',
+  'com.daml.daml_lf_1.DamlLf.ArchivePayload',
+  'com.daml.daml_lf_1.DamlLf1.ArchivePayload',
+]
+const packageCandidates = [
+  'com.daml.daml_lf_dev.DamlLf.Package',
+  'com.daml.daml_lf_dev.DamlLf1.Package',
+  'com.daml.daml_lf_1.DamlLf.Package',
+  'com.daml.daml_lf_1.DamlLf1.Package',
+]
+
+// Resolve whichever candidate protobuf messages exist in the loaded schema.
+// This supports small package-name differences across Daml-LF versions.
+function lookupTypes(root: any, candidates: string[]) {
+  return candidates
+    .map((name) => {
+      try {
+        return { name, type: root.lookupType(name) }
+      } catch {
+        return null
+      }
+    })
+    .filter(Boolean) as Array<{ name: string; type: any }>
+}
+
+function tryDecodeWithType(name: string, type: any, bytes: Buffer): { name: string; decoded: AnyObject } | null {
+  try {
+    return { name, decoded: safeToObject(type, type.decode(bytes)) }
+  } catch {
+    return null
+  }
+}
+
+// Decode using multiple strategies and record all failed attempts for debugging.
+function decodeDalf(root: any, bytes: Buffer) {
+  const payloadTypes = lookupTypes(root, payloadCandidates)
+  const archiveTypes = lookupTypes(root, archiveCandidates)
+  const packageTypes = lookupTypes(root, packageCandidates)
+
+  const attempts: string[] = []
+
+  for (const p of payloadTypes) {
+    const decoded = tryDecodeWithType(p.name, p.type, bytes)
+    if (decoded) return { strategy: `direct:${p.name}`, decoded: decoded.decoded, attempts }
+    attempts.push(`fail direct ${p.name}`)
+  }
+
+  for (const a of archiveTypes) {
+    const archiveDecoded = tryDecodeWithType(a.name, a.type, bytes)
+    if (!archiveDecoded) {
+      attempts.push(`fail archive ${a.name}`)
+      continue
+    }
+
+    const payload = archiveDecoded.decoded.payload
+    if (!payload) {
+      attempts.push(`archive ${a.name} had no payload field`) // useful debug signal
+      continue
+    }
+
+    const payloadBytes = Buffer.from(payload)
+    for (const p of payloadTypes) {
+      const decodedPayload = tryDecodeWithType(p.name, p.type, payloadBytes)
+      if (decodedPayload) {
+        return {
+          strategy: `archive:${a.name} -> payload:${p.name}`,
+          decoded: {
+            archive: archiveDecoded.decoded,
+            payload: decodedPayload.decoded,
+          },
+          attempts,
+        }
+      }
+      attempts.push(`fail payload ${p.name} after ${a.name}`)
+    }
+
+    for (const p of packageTypes) {
+      const decodedPackage = tryDecodeWithType(p.name, p.type, payloadBytes)
+      if (decodedPackage) {
+        return {
+          strategy: `archive:${a.name} -> package:${p.name}`,
+          decoded: {
+            archive: archiveDecoded.decoded,
+            pkg: decodedPackage.decoded,
+          },
+          attempts,
+        }
+      }
+      attempts.push(`fail package ${p.name} after ${a.name}`)
+    }
+  }
+
+  throw new Error(`Unable to decode DALF with loaded protobuf types. Attempts: ${attempts.join(' | ')}`)
+}
+
+function walk(node: any, visitor: (value: AnyObject, pathBits: string[]) => void, pathBits: string[] = []) {
+  if (Array.isArray(node)) return node.forEach((item, idx) => walk(item, visitor, [...pathBits, String(idx)]))
+  if (!node || typeof node !== 'object') return
+  visitor(node as AnyObject, pathBits)
+  Object.entries(node).forEach(([key, value]) => walk(value, visitor, [...pathBits, key]))
+}
+
+// Normalize location access because objects may expose `location` or `loc`.
+function pickLocation(raw: AnyObject): AnyObject | null {
+  if (raw.location && typeof raw.location === 'object') return raw.location
+  if (raw.loc && typeof raw.loc === 'object') return raw.loc
+  return null
+}
+
+// Report expression shape by top-level keys only (spike-level granularity).
+function exprShape(node: unknown): string {
+  if (!node || typeof node !== 'object') return 'missing'
+  const keys = Object.keys(node as AnyObject).filter((k) => k !== 'location')
+  return keys.join('|') || 'empty'
+}
+
+// Summarize source-location quality signals for manual cross-checking.
+function analyzeLocationQuality(locationNodes: LocatedRaw[]) {
+  const details = locationNodes.map((node) => {
+    const loc = node.location ?? {}
+    const file = loc.file || loc.filename || loc.moduleFilename || loc.source || null
+    const range = loc.range || {}
+    const line = range.startLine ?? loc.startLine ?? null
+    const col = range.startCol ?? loc.startCol ?? null
+
+    let fileKind = 'absent'
+    if (typeof file === 'string' && file.length > 0) {
+      if (file.endsWith('.daml')) fileKind = 'original_daml'
+      else if (file.includes('daml') || file.includes('DA.')) fileKind = 'internal_or_generated'
+      else fileKind = 'unknown'
+    }
+
+    return {
+      path: node.path,
+      file,
+      line,
+      col,
+      fileKind,
+      raw: node.location,
+    }
+  })
+
+  return {
+    exists: details.length > 0,
+    total: details.length,
+    originalDamlRefs: details.filter((d) => d.fileKind === 'original_daml').length,
+    internalRefs: details.filter((d) => d.fileKind === 'internal_or_generated').length,
+    missingFileRefs: details.filter((d) => d.fileKind === 'absent').length,
+    samples: details.slice(0, 30),
+  }
+}
+
+// Heuristic extraction pass: collect raw candidates without assuming strict schema fields.
+function extractConstructs(decoded: AnyObject) {
+  const out = {
+    templates: [] as LocatedRaw[],
+    choices: [] as LocatedRaw[],
+    signatories: [] as LocatedRaw[],
+    observers: [] as LocatedRaw[],
+    contractKeys: [] as LocatedRaw[],
+    interfaces: [] as LocatedRaw[],
+    sourceLocations: [] as LocatedRaw[],
+  }
+
+  // Traverse all nodes and bucket matches by shape/path hints.
+  walk(decoded, (raw, pathBits) => {
+    const keys = Object.keys(raw)
+    const lower = keys.map((k) => k.toLowerCase())
+    const pathText = pathBits.join('.')
+    const located = { path: pathText, raw, location: pickLocation(raw) }
+
+    if ((lower.includes('signatories') && lower.includes('choices')) || pathText.toLowerCase().includes('template')) out.templates.push(located)
+    if (lower.includes('consuming') || lower.includes('controllers')) out.choices.push(located)
+    if (lower.includes('signatories')) out.signatories.push({ ...located, raw: raw.signatories ?? raw })
+    if (lower.includes('observers')) out.observers.push({ ...located, raw: raw.observers ?? raw })
+    if (lower.includes('key') || lower.includes('maintainers')) {
+      if (pathText.toLowerCase().includes('key')) out.contractKeys.push(located)
+    }
+    if (pathText.toLowerCase().includes('interface') || lower.includes('methods') || lower.includes('requires')) out.interfaces.push(located)
+
+    if (
+      lower.includes('location') ||
+      lower.includes('modulefilename') ||
+      lower.includes('startline') ||
+      lower.includes('start_line')
+    ) {
+      out.sourceLocations.push(located)
+    }
+  })
+
+  const choiceSummary = out.choices.map((c) => ({
+    path: c.path,
+    name: c.raw.name ?? c.raw.nameInternedStr ?? '(unknown)',
+    consuming: c.raw.consuming ?? null,
+    controllerExpr: exprShape(c.raw.controllers),
+    observerExpr: exprShape(c.raw.observers),
+    returnTypeExpr: exprShape(c.raw.retType ?? c.raw.returnType),
+    raw: c.raw,
+    location: c.location,
+  }))
+
+  const templateSummary = out.templates.map((t) => ({
+    path: t.path,
+    name: t.raw.name ?? t.raw.tycon ?? '(unknown)',
+    module: t.raw.module ?? null,
+    fields: t.raw.fields ?? t.raw.record?.fields ?? null,
+    signatoryExpr: exprShape(t.raw.signatories),
+    observerExpr: exprShape(t.raw.observers),
+    raw: t.raw,
+    location: t.location,
+  }))
+
+  const locationQuality = analyzeLocationQuality(out.sourceLocations)
+
+  return {
+    found: Object.fromEntries(Object.entries(out).map(([k, v]) => [k, v.length > 0])),
+    counts: Object.fromEntries(Object.entries(out).map(([k, v]) => [k, v.length])),
+    templates: templateSummary,
+    choices: choiceSummary,
+    signatories: out.signatories,
+    observers: out.observers,
+    contractKeys: out.contractKeys,
+    interfaces: out.interfaces,
+    sourceLocations: out.sourceLocations,
+    sourceLocationQuality: locationQuality,
+  }
+}
+
+function renderFindingsReport(inputName: string, decodeStrategy: string, constructs: AnyObject) {
+  const templatesFound = constructs.counts.templates > 0 ? 'Yes' : 'No'
+  const choicesFound = constructs.counts.choices > 0 ? 'Yes' : 'No'
+  const signatoryReadability = constructs.signatories.some((s: any) => String(exprShape(s.raw)).includes('abs'))
+    ? 'Lambda'
+    : constructs.counts.signatories > 0
+      ? 'Structured'
+      : 'Mixed'
+  const loc = constructs.sourceLocationQuality
+
+  return `# DAML-LF Spike Findings\n\n- Input: ${inputName}\n- Decode strategy: ${decodeStrategy}\n\n## Answers\n\n1. Is the Daml-LF protobuf decodable with protobufjs without a JVM?\n   - Yes (for this sample with strategy: ${decodeStrategy}).\n2. Are template and choice definitions present as structured data?\n   - ${templatesFound === 'Yes' || choicesFound === 'Yes' ? 'Partially' : 'No'} (templates=${templatesFound}, choices=${choicesFound}).\n3. Are signatory and controller expressions readable as structured data or opaque lambda expressions?\n   - ${signatoryReadability}.\n4. Do source locations exist and point to original .daml source with accurate line/column?\n   - ${loc.exists ? 'Partially' : 'No'} (locations=${loc.total}, originalDamlRefs=${loc.originalDamlRefs}, internalRefs=${loc.internalRefs}, missingFileRefs=${loc.missingFileRefs}).\n5. What is the actual recommended input pipeline?\n   - .dalf directly (or .dar -> .dalf extraction) with protobufjs decode and post-processing over raw JSON.\n6. What are the real blockers for building a visitor-based linter on top of this?\n   - Schema/version drift between DALF and protobuf definitions.\n   - Potentially lambda-heavy signatory/controller expressions requiring expression visitor logic.\n   - Source location fidelity may be partial and needs manual verification against original .daml files.\n\n## Manual line/column validation checklist\n\n- Pick entries from \`*.constructs.json -> sourceLocationQuality.samples\`.\n- Open corresponding original \`.daml\` file and verify line/column points to expected construct.\n- Record mismatches if location appears module-only or generated/internal.\n`
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2))
+  if (!args.input) throw new Error('Usage: node research/daml-lf/dalf_probe.ts <input.dar|input.dalf> --proto <path/to/proto> [--out-dir dir]')
+  if (!args.proto || !fs.existsSync(args.proto)) throw new Error('Missing --proto path. Point to official Daml-LF .proto.')
+  if (!fs.existsSync(args.input)) throw new Error(`Input not found: ${args.input}`)
+
+  const deps = await loadDependencies()
+  ensureDir(args.outDir)
+
+  // Load official Daml-LF protobuf schema from local path.
+  const root = await deps.protobufjs.load(args.proto)
+  const dalfs = collectDalfFromInput(args.input, deps.AdmZip)
+  const summary: AnyObject[] = []
+
+  // Analyze every DALF independently to avoid coupling failures across entries.
+  for (const dalf of dalfs) {
+    const decoded = decodeDalf(root, dalf.bytes)
+    const constructs = extractConstructs(decoded.decoded)
+
+    const base = dalf.name.replace(/[^a-zA-Z0-9_.-]/g, '_')
+    const decodedPath = path.join(args.outDir, `${base}.decoded.json`)
+    const constructsPath = path.join(args.outDir, `${base}.constructs.json`)
+    const reportPath = path.join(args.outDir, `${base}.findings.md`)
+
+    fs.writeFileSync(decodedPath, JSON.stringify(decoded, null, 2))
+    fs.writeFileSync(constructsPath, JSON.stringify(constructs, null, 2))
+    fs.writeFileSync(reportPath, renderFindingsReport(dalf.name, decoded.strategy, constructs))
+
+    summary.push({
+      dalf: dalf.name,
+      decodeStrategy: decoded.strategy,
+      decodedPath,
+      constructsPath,
+      reportPath,
+      found: constructs.found,
+    })
+  }
+
+  const summaryPath = path.join(args.outDir, 'summary.json')
+  fs.writeFileSync(summaryPath, JSON.stringify(summary, null, 2))
+  console.log(`Wrote ${summary.length} DALF analysis result(s) into ${args.outDir}`)
+  console.log(`Summary: ${summaryPath}`)
+}
+
+main().catch((err) => {
+  console.error('[dalf-probe] fatal:', err.message)
+  process.exitCode = 1
+})

--- a/research/daml-lf/findings.md
+++ b/research/daml-lf/findings.md
@@ -1,0 +1,41 @@
+# DAML-LF protobufjs feasibility spike
+
+This folder now contains an upgraded probe script (`dalf_probe.ts`) that combines:
+
+- strict decode-first flow from the initial spike,
+- richer extraction/report ideas from your reference script,
+- and explicit handling for DALF schema/version ambiguity.
+
+## What changed in the upgraded script
+
+1. **Decode strategies are now layered**:
+   - direct decode as `ArchivePayload`,
+   - or `Archive -> payload -> ArchivePayload/Package` fallback.
+2. **DAR handling improved**:
+   - all `.dalf` entries are extracted,
+   - likely project DALF is prioritized over stdlib-like entries.
+3. **Construct extraction now includes richer summaries**:
+   - template summaries (name/module/fields/signatory+observer expr shape),
+   - choice summaries (consuming, controller/observer expr shape, return type hint),
+   - raw structures are still preserved for every construct class.
+4. **Source-location quality analysis added**:
+   - counts original `.daml` references vs internal/generated vs missing file refs,
+   - outputs a sample set for manual line/column cross-checking.
+5. **Per-DALF markdown report generated automatically**:
+   - answers the binary research questions,
+   - includes a manual verification checklist for location fidelity.
+
+## Output files
+
+For each analyzed DALF the script writes:
+
+- `*.decoded.json`
+- `*.constructs.json`
+- `*.findings.md`
+- `summary.json`
+
+## Important constraints still true
+
+- The script still requires local installation of `protobufjs` + `adm-zip`.
+- The script still requires a local official Daml-LF `.proto` via `--proto`.
+- Final truth about location accuracy requires real `.dalf` + matching `.daml` source and manual cross-check.


### PR DESCRIPTION
### Motivation

- Provide a standalone research spike to validate whether `.dalf`/`.dar` artifacts can be decoded in Node.js with `protobufjs` (no JVM) and contain enough structured info for a visitor-based static analyzer. 
- Extract and summarize templates, choices, signatories/observers/keys/interfaces and measure source-location fidelity to decide next steps for a linter pipeline. 
- Make the probe runnable as an independent package and also available under `research/daml-lf` for integration with the repository documentation and workflows.

### Description

- Add a new spike package under `daml-lf-viability-spike/` containing `src/dalf_probe.ts`, `package.json`, `tsconfig.json`, `README.md`, `LICENSE`, `.gitignore`, `PUSH_TO_NEW_REPO.md`, and `docs/findings.md`. 
- Implement a CLI probe (`dalf_probe.ts`) that accepts `.dalf` or `.dar` inputs and a local Daml-LF `.proto` file and writes per-DALF outputs: `*.decoded.json`, `*.constructs.json`, `*.findings.md`, and a global `summary.json`. 
- Implement layered decode strategies with `protobufjs` (direct `ArchivePayload`, `Archive -> payload -> ArchivePayload`, and `Archive -> payload -> Package`) plus DAR handling via `adm-zip`, candidate type lookup for schema/version tolerance, and per-attempt diagnostics. 
- Add heuristic construct extraction and source-location quality analysis (templates, choices, signatories, observers, keys, interfaces, expression-shape hints) and render a human-readable findings report; duplicate the same probe under `research/daml-lf/` with supporting `findings.md`. 

### Testing

- No automated tests were executed as part of this change; the package includes npm scripts for manual verification (`npm run probe`, `npm run probe:node`, `npm run check`, and `npm run build`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1805eb624832eafa8ad20f99eb59f)