### PR TITLE
docs: fix broken consensys guide link

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -104,5 +104,5 @@ title:       "Rule Index of Solhint"
 
 ## References
 
-- [ConsenSys Guide for Smart Contracts](https://consensys.github.io/smart-contract-best-practices/development-recommendations/)
+- [ConsenSys Guide for Smart Contracts](https://consensysdiligence.github.io/smart-contract-best-practices/)
 - [Solidity Style Guide](http://solidity.readthedocs.io/en/develop/style-guide.html)


### PR DESCRIPTION
## Description

The "ConsenSys Guide for Smart Contracts" link in `docs/rules.md` pointed to `consensys.github.io/smart-contract-best-practices/development-recommendations/`, which no longer resolves. The best-practices guide has moved to the ConsenSys Diligence organization.

This updates the reference to the current canonical URL:

`https://consensysdiligence.github.io/smart-contract-best-practices/`

## Changes

- Fix broken ConsenSys guide link in the References section of `docs/rules.md`

## Type of change

- [x] Documentation update
